### PR TITLE
Fix load logs in loaders to correct output loader (and child loaders) logs

### DIFF
--- a/csunplugged/topics/management/commands/BaseLoader.py
+++ b/csunplugged/topics/management/commands/BaseLoader.py
@@ -8,9 +8,12 @@ from kordac import Kordac
 
 class BaseLoader():
     """Base loader class for individual loaders"""
-    load_log = []
 
-    def __init__(self):
+    def __init__(self, load_log=[]):
+        if load_log:
+            self.load_log = load_log
+        else:
+            self.load_log = list(load_log)
         self.BASE_PATH = 'topics/content/en/' # TODO: Hardcoded for prototype
         self.language_structure = self.load_yaml_file('structure.yaml')
         self.setup_md_to_html_converter()
@@ -35,6 +38,7 @@ class BaseLoader():
         """Output log messages from loader to console"""
         for (log, indent) in self.load_log:
             sys.stdout.write('{indent}{text}\n'.format(indent='  '*indent, text=log))
+        sys.stdout.write('\n')
         self.load_log = []
 
     def convert_md_file(self, file_path):
@@ -64,5 +68,3 @@ class BaseLoader():
     @abc.abstractmethod
     def load(self):
         raise NotImplementedError('subclass does not implement this method')
-
-

--- a/csunplugged/topics/management/commands/FollowUpActivitiesLoader.py
+++ b/csunplugged/topics/management/commands/FollowUpActivitiesLoader.py
@@ -5,14 +5,14 @@ from topics.models import CurriculumLink
 class FollowUpActivitiesLoader(BaseLoader):
     """Loader for follow up activites"""
 
-    def __init__(self, follow_up_activities_structure_file, topic):
+    def __init__(self, load_log, follow_up_activities_structure_file, topic):
         """Initiates the loader for follow up activites
 
         Args:
             follow_up_activities_structure_file: file path (string)
             topic: Topic model object
         """
-        super().__init__()
+        super().__init__(load_log)
         self.follow_up_activities_structure_file = follow_up_activities_structure_file
         self.topic = topic
 
@@ -38,4 +38,3 @@ class FollowUpActivitiesLoader(BaseLoader):
                     activity.curriculum_links.add(object)
 
                 self.load_log.append(('Added Activity: {}'.format(activity.name), 1))
-

--- a/csunplugged/topics/management/commands/LessonLoader.py
+++ b/csunplugged/topics/management/commands/LessonLoader.py
@@ -5,7 +5,7 @@ from topics.models import Age, LearningOutcome, CurriculumLink, ClassroomResourc
 class LessonLoader(BaseLoader):
     """Loader for a single lesson"""
 
-    def __init__(self, lesson_structure, topic, unit_plan):
+    def __init__(self, load_log, lesson_structure, topic, unit_plan):
         """Initiates the loader for a single lesson
 
         Args:
@@ -13,7 +13,7 @@ class LessonLoader(BaseLoader):
             topic: Topic model object
             unit_plan: UnitPlan model object
         """
-        super().__init__()
+        super().__init__(load_log)
         self.lesson_structure = lesson_structure
         self.topic = topic
         self.unit_plan = unit_plan
@@ -72,4 +72,3 @@ class LessonLoader(BaseLoader):
                 relationship.save()
 
         self.load_log.append(('Added Lesson: {}'.format(lesson.__str__()), 2))
-

--- a/csunplugged/topics/management/commands/LessonsLoader.py
+++ b/csunplugged/topics/management/commands/LessonsLoader.py
@@ -6,7 +6,7 @@ from topics.models import CurriculumLink
 class LessonsLoader(BaseLoader):
     """Loader for lessons"""
 
-    def __init__(self, lessons_structure, topic, unit_plan):
+    def __init__(self, load_log, lessons_structure, topic, unit_plan):
         """Inititiates the loader for lessons
 
         Args:
@@ -14,7 +14,7 @@ class LessonsLoader(BaseLoader):
             topic: Topic model object
             unit_plan: UnitPlan model object
         """
-        super().__init__()
+        super().__init__(load_log)
         self.lessons_structure = lessons_structure
         self.topic = topic
         self.unit_plan = unit_plan
@@ -22,4 +22,4 @@ class LessonsLoader(BaseLoader):
     def load(self):
         """Call (single) LessonLoader for each lesson to load into db"""
         for lesson_structure in self.lessons_structure:
-            LessonLoader(lesson_structure, self.topic, self.unit_plan).load()
+            LessonLoader(self.load_log, lesson_structure, self.topic, self.unit_plan).load()

--- a/csunplugged/topics/management/commands/ProgrammingExercisesLoader.py
+++ b/csunplugged/topics/management/commands/ProgrammingExercisesLoader.py
@@ -5,14 +5,14 @@ from topics.models import LearningOutcome, ProgrammingExerciseDifficulty
 class ProgrammingExercisesLoader(BaseLoader):
     """Loader for programming exercises"""
 
-    def __init__(self, programming_exercises_structure_file, topic):
+    def __init__(self, load_log, programming_exercises_structure_file, topic):
         """Initiates the loader for programming exercises
 
         Args:
             programming_exercises_structure_file: file path (string)
             topic: Topic model object
         """
-        super().__init__()
+        super().__init__(load_log)
         self.programming_exercises_structure_file = programming_exercises_structure_file
         self.topic = topic
 
@@ -46,4 +46,3 @@ class ProgrammingExercisesLoader(BaseLoader):
                     programming_exercise.learning_outcomes.add(learning_outcome)
 
                 self.load_log.append(('Added Programming Exercise: {}'.format(programming_exercise.name), 1))
-

--- a/csunplugged/topics/management/commands/TopicsLoader.py
+++ b/csunplugged/topics/management/commands/TopicsLoader.py
@@ -45,15 +45,15 @@ class TopicsLoader(BaseLoader):
 
             # Load unit plans
             for unit_plan_structure_file in topic_structure['unit-plans']:
-                UnitPlanLoader(unit_plan_structure_file, topic).load()
+                UnitPlanLoader(self.load_log, unit_plan_structure_file, topic).load()
 
             # Load programming exercises (if there are any)
             if topic_structure['programming-exercises']:
-                ProgrammingExercisesLoader(topic_structure['programming-exercises'], topic).load()
+                ProgrammingExercisesLoader(self.load_log, topic_structure['programming-exercises'], topic).load()
 
             # Load follow up activities (if there are any)
             if topic_structure['follow-up-activities']:
-                FollowUpActivitiesLoader(topic_structure['follow-up-activities'], topic).load()
+                FollowUpActivitiesLoader(self.load_log, topic_structure['follow-up-activities'], topic).load()
 
         # Print log output
         self.print_load_log()

--- a/csunplugged/topics/management/commands/UnitPlanLoader.py
+++ b/csunplugged/topics/management/commands/UnitPlanLoader.py
@@ -4,14 +4,14 @@ from topics.management.commands.LessonsLoader import LessonsLoader
 class UnitPlanLoader(BaseLoader):
     """Loader for unit plans"""
 
-    def __init__(self, unit_plan_structure_file, topic):
+    def __init__(self, load_log, unit_plan_structure_file, topic):
         """Initiates the loader for unit plans
 
         Args:
             unit_plan_structure_file: file path (string)
             topic: Topic model object
         """
-        super().__init__()
+        super().__init__(load_log)
         self.unit_plan_structure_file = unit_plan_structure_file
         self.topic = topic
 
@@ -30,4 +30,4 @@ class UnitPlanLoader(BaseLoader):
         self.load_log.append(('Added Unit Plan: {}'.format(unit_plan.name), 1))
 
         lessons_structure = unit_plan_structure['lessons']
-        LessonsLoader(lessons_structure, self.topic, unit_plan).load()
+        LessonsLoader(self.load_log, lessons_structure, self.topic, unit_plan).load()

--- a/csunplugged/topics/management/commands/loadtopics.py
+++ b/csunplugged/topics/management/commands/loadtopics.py
@@ -22,4 +22,3 @@ class Command(BaseCommand):
         LearningOutcomesLoader(learning_outcomes_file).load()
         ProgrammingExercisesDifficultiesLoader(difficulty_file).load()
         TopicsLoader(structure_file).load()
-


### PR DESCRIPTION
The load_log was stored as an class variable instead of an instance variable, so all instances of the class were sharing the same variable. It doesn't seem possible to overwrite this variable so it made sense to switch to an variable for each instance.

The BaseLoader class initialiser now sets the load log variable. If none is given in a loaders`` __init__()`` then a new list is created (passed through list() to avoid Python using previous load logs in memory). If a load log is given, it saves a reference to this list.

All loaders which call another loader pass the reference to their load log for the loader to append to.

Another possible solution was to not print the load log until all loading is complete, however as we create more loaders for more applications, it seems restrictive that we can't print load log throughout the process. This solution avoids this issue, as each load log is independent of each group.

This is related to #46.