### PR TITLE
Prevent selecting and copying solution text for programming exercises (fixes #88)

### DIFF
--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -6,33 +6,43 @@ img {
     height: 30px;
     margin-right: 1rem;
   }
+
   &.resource-thumbnail {
     max-height: 15rem;
   }
+
   &.topic-img-logo {
     height: 200px;
     object-fit: contain;
   }
+
   &.plugged-in-language-icon {
     height: 1.5em;
   }
 }
-h1, h2, h3 {
+
+h1,
+h2,
+h3 {
   color: #e33333;
   margin-top: 1.5rem;
+
   span.subtitle {
     color: #888;
   }
 }
+
 input[type="text"].long-text-field {
   width: 20em;
 }
+
 div.plugged-in-language-implementation {
-  padding: 0 1em 1em 1em;
   border: 1px #e33333 solid;
   border-radius: 0.5em;
   margin: 1em 0;
+  padding: 0 1em 1em 1em;
 }
+
 .disable-selection {
   user-select: none;
 }

--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -33,3 +33,6 @@ div.plugged-in-language-implementation {
   border-radius: 0.5em;
   margin: 1em 0;
 }
+.disable-selection {
+  user-select: none;
+}

--- a/csunplugged/templates/topics/programming_exercise_language_solution.html
+++ b/csunplugged/templates/topics/programming_exercise_language_solution.html
@@ -14,7 +14,9 @@
 
 <p>This is just one of many possible solutions.</p>
 
-{% render_html_field implementation.solution %}
+<div class="disable-selection">
+  {% render_html_field implementation.solution %}
+</div>
 
 <p>
   <a href="{% url 'topics:programming_exercise' implementation.topic.slug implementation.exercise.slug %}" class="btn btn-outline-danger">


### PR DESCRIPTION
This is a basic solution (that should work for most browsers), but we have decided that users who copy solutions from the source code are fine to do so (they could probably solve the exercise anyway).

This also updates `website.scss` to Google's CSS Style Guide.