### PR TITLE
Rename loaddata to updatedata

### DIFF
--- a/csunplugged/general/management/commands/updatedata.py
+++ b/csunplugged/general/management/commands/updatedata.py
@@ -2,10 +2,10 @@ from django.core import management
 
 
 class Command(management.base.BaseCommand):
-    help = 'Flush and load data for all applications'
+    help = 'Update all data from content folders for all applications'
 
     def handle(self, *args, **options):
-        """The function called when the loaddata command is given"""
+        """The function called when the updatedata command is given"""
         management.call_command('flush', interactive=False)
         management.call_command('loadresources')
         management.call_command('loadtopics')

--- a/docs/source/getting_started/install_developer.rst
+++ b/docs/source/getting_started/install_developer.rst
@@ -318,7 +318,7 @@ in more detail on the next page):
 .. code-block:: bash
 
     $ python manage.py migrate
-    $ python manage.py loaddata
+    $ python manage.py updatedata
     $ python manage.py runserver
 
 Leave this terminal running and open a new terminal in the same


### PR DESCRIPTION
Rename `loaddata` to `updatedata` to avoid conflict with existing Django command.

This fixes #99.