### PR TITLE
Remove topic query from homepage (fixes #186)

### DIFF
--- a/csunplugged/general/views.py
+++ b/csunplugged/general/views.py
@@ -4,5 +4,6 @@ from django.views.generic import TemplateView
 class GeneralIndexView(TemplateView):
     template_name = 'general/index.html'
 
+
 class GeneralAboutView(TemplateView):
     template_name = 'general/about.html'

--- a/csunplugged/general/views.py
+++ b/csunplugged/general/views.py
@@ -4,14 +4,5 @@ from django.views.generic import TemplateView
 class GeneralIndexView(TemplateView):
     template_name = 'general/index.html'
 
-    def get_context_data(self, **kwargs):
-        # TODO: Investigate if importing model from another
-        # app is sensible/best approach.
-        from topics.models import Topic
-        context = super(GeneralIndexView, self).get_context_data(**kwargs)
-        context['total_topics'] = Topic.objects.count()
-        return context
-
-
 class GeneralAboutView(TemplateView):
     template_name = 'general/about.html'


### PR DESCRIPTION
This removed an unnecessary query (saves 80 ms on my local development machine).

Fixes #186.
Security fixes are done in #193 or #196.