### PR TITLE
Update programming terms on templates (fixes #176)

### DIFF
--- a/csunplugged/templates/topics/lesson.html
+++ b/csunplugged/templates/topics/lesson.html
@@ -43,15 +43,15 @@
 {{ lesson.content }}
 {% endautoescape %}
 
-<h2>Plugged In <span class="subtitle">(programming exercises)</span></h2>
+<h2>Plugged In <span class="subtitle">(programming challenges)</span></h2>
 {% if programming_exercises %}
   <p>
     <a href="{% url 'topics:programming_exercises_list' topic.slug unit_plan.slug lesson.slug %}" class="btn btn-outline-danger">
-      Programming exercises for {{ lesson.name }}
+      Programming challenges for {{ lesson.name }}
     </a>
   </p>
 {% else %}
-  <p>No programming exercises for {{ lesson.name }}.</p>
+  <p>No programming challenges for {{ lesson.name }}.</p>
 {% endif %}
 
 <h2>Learning Outcomes</h2>

--- a/csunplugged/templates/topics/programming_exercise.html
+++ b/csunplugged/templates/topics/programming_exercise.html
@@ -16,7 +16,7 @@
   </h1>
 
   <p>
-    <strong>Difficulty:</strong> {{ programming_exercise.difficulty.name }}
+    <strong>Challenge Level:</strong> {{ programming_exercise.difficulty.name }}
   </p>
 
   {% autoescape off %}

--- a/csunplugged/templates/topics/programming_exercise_difficulty.html
+++ b/csunplugged/templates/topics/programming_exercise_difficulty.html
@@ -4,9 +4,9 @@
 
 <h1>{{ difficulty.name }}</h1>
 
-<p><strong>Difficulty level:</strong> {{ difficulty.level }}</p>
+<p><strong>Challenge level:</strong> {{ difficulty.level }}</p>
 
-<h2>Programming Exercises</h2>
+<h2>Programming Challenges</h2>
 {% if programming_exercises %}
   <ul>
   {% for programming_exercise in programming_exercises %}
@@ -16,7 +16,7 @@
   {% endfor %}
 </ul>
 {% else %}
-  <p>No programming exercises for difficulty {{ difficulty.name }}.</p>
+  <p>No programming challenges for challenge {{ difficulty.name }}.</p>
 {% endif %}
 
 {% endblock content %}

--- a/csunplugged/templates/topics/programming_exercise_list.html
+++ b/csunplugged/templates/topics/programming_exercise_list.html
@@ -8,7 +8,7 @@
 {% endblock breadcrumbs %}
 
 {% block content %}
-  <h1>{{ lesson.name }} Programming Exercises</h1>
+  <h1>{{ lesson.name }} Programming Challenges</h1>
 
   {% if all_programming_exercises %}
     {% for programming_exercise in all_programming_exercises %}
@@ -20,7 +20,7 @@
       </p>
     {% endfor %}
   {% else %}
-    <p>No programming exercises for {{ topic }}.</p>
+    <p>No programming challenges for {{ topic }}.</p>
   {% endif %}
 
 {% endblock content %}

--- a/csunplugged/templates/topics/topic.html
+++ b/csunplugged/templates/topics/topic.html
@@ -37,7 +37,7 @@
                 <ul>
                   <li>
                     <a href="{% url 'topics:programming_exercises_list' topic.slug unit_plan.slug lesson.slug %}">
-                      View Lesson Programming Exercises
+                      View Lesson Programming Challenges
                     </a>
                   </li>
                 </ul>


### PR DESCRIPTION
The backend still uses old terms, as these are clearer for developers.

Fixes #176.
Security fixes are done in #193 or #196.