### PR TITLE
Add about pages (fixes #207)

### DIFF
--- a/csunplugged/general/urls.py
+++ b/csunplugged/general/urls.py
@@ -6,5 +6,6 @@ from . import views
 
 urlpatterns = [
     url(r'^about/$', views.GeneralAboutView.as_view(), name='about'),
+    url(r'^principles/$', views.GeneralPrinciplesView.as_view(), name='principles'),
     url(r'^$', views.GeneralIndexView.as_view(), name='home'),
 ]

--- a/csunplugged/general/urls.py
+++ b/csunplugged/general/urls.py
@@ -6,6 +6,7 @@ from . import views
 
 urlpatterns = [
     url(r'^about/$', views.GeneralAboutView.as_view(), name='about'),
+    url(r'^contact/$', views.GeneralContactView.as_view(), name='contact'),
     url(r'^principles/$', views.GeneralPrinciplesView.as_view(), name='principles'),
     url(r'^$', views.GeneralIndexView.as_view(), name='home'),
 ]

--- a/csunplugged/general/urls.py
+++ b/csunplugged/general/urls.py
@@ -7,6 +7,7 @@ from . import views
 urlpatterns = [
     url(r'^about/$', views.GeneralAboutView.as_view(), name='about'),
     url(r'^contact/$', views.GeneralContactView.as_view(), name='contact'),
+    url(r'^people/$', views.GeneralPeopleView.as_view(), name='people'),
     url(r'^principles/$', views.GeneralPrinciplesView.as_view(), name='principles'),
     url(r'^$', views.GeneralIndexView.as_view(), name='home'),
 ]

--- a/csunplugged/general/views.py
+++ b/csunplugged/general/views.py
@@ -22,6 +22,12 @@ class GeneralContactView(TemplateView):
     template_name = 'general/contact.html'
 
 
+class GeneralPeopleView(TemplateView):
+    """View for the people page that renders from a template."""
+
+    template_name = 'general/people.html'
+
+
 class GeneralPrinciplesView(TemplateView):
     """View for the princples page that renders from a template."""
 

--- a/csunplugged/general/views.py
+++ b/csunplugged/general/views.py
@@ -16,6 +16,12 @@ class GeneralAboutView(TemplateView):
     template_name = 'general/about.html'
 
 
+class GeneralContactView(TemplateView):
+    """View for the contact page that renders from a template."""
+
+    template_name = 'general/contact.html'
+
+
 class GeneralPrinciplesView(TemplateView):
     """View for the princples page that renders from a template."""
 

--- a/csunplugged/general/views.py
+++ b/csunplugged/general/views.py
@@ -16,6 +16,12 @@ class GeneralAboutView(TemplateView):
     template_name = 'general/about.html'
 
 
+class GeneralPrinciplesView(TemplateView):
+    """View for the princples page that renders from a template."""
+
+    template_name = 'general/principles.html'
+
+
 def health_check(request):
     """Return heath check response for Google App Engine.
 

--- a/csunplugged/templates/base.html
+++ b/csunplugged/templates/base.html
@@ -114,7 +114,7 @@
             </a>
           </li>
           <li>
-            <a href="#">
+            <a href="{% url 'general:contact' %}">
               Contact
             </a>
           </li>

--- a/csunplugged/templates/general/about.html
+++ b/csunplugged/templates/general/about.html
@@ -9,5 +9,23 @@
 
 {% block content %}
   <h1>{% trans 'About' %}</h1>
-  <p>This website is a prototype for the new CS Unplugged content.</p>
+
+  <p>
+    CS Unplugged is a collection of free learning activities that teach Computer Science through engaging games and puzzles that use cards, string, crayons and lots of running around.
+    We originally developed this so that young students could dive head-first into computer science, experiencing the kinds of questions and challenges that computer scientists experience, but without having to learn programming first.
+  </p>
+
+  <p>
+    The collection was originally intended as a resource for outreach and extension, but with the adoption of computing and computational thinking into many classrooms around the world, it is now widely used for teaching.
+    The material has been used in many contexts outside the classroom as well, including science shows, talks for senior citizens, and special events.
+  </p>
+
+  <p>
+    Thanks to generous sponsorships we have been able to create associated resources such as the videos, which are intended to help teachers see how the activities work (please don’t show them to your classes – let them experience the activities themselves!).
+    All of the activities that we provide are “open source” – they are released under a Creative Commons BY-NC-SA licence, so you can copy, share and modify the material.
+  </p>
+
+  <p>
+    For more information about the principles behind CS Unplugged, see our <a href="{% url 'general:principles' %}">principles page</a>.
+  </p>
 {% endblock %}

--- a/csunplugged/templates/general/about.html
+++ b/csunplugged/templates/general/about.html
@@ -26,6 +26,10 @@
   </p>
 
   <p>
+    For details on how to contact us, see our <a href="{% url 'general:contact' %}">contact us page</a>.
+  </p>
+
+  <p>
     For more information about the principles behind CS Unplugged, see our <a href="{% url 'general:principles' %}">principles page</a>.
   </p>
 {% endblock %}

--- a/csunplugged/templates/general/about.html
+++ b/csunplugged/templates/general/about.html
@@ -26,6 +26,10 @@
   </p>
 
   <p>
+    To view the team of contributors who work on this project, see our <a href="{% url 'general:people' %}">people page</a>.
+  </p>
+
+  <p>
     For details on how to contact us, see our <a href="{% url 'general:contact' %}">contact us page</a>.
   </p>
 

--- a/csunplugged/templates/general/contact.html
+++ b/csunplugged/templates/general/contact.html
@@ -1,0 +1,26 @@
+{% extends "general/about.html" %}
+{% load i18n %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  {% breadcrumb "Contact" "general:contact" %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <h1>{% trans 'Contact Us' %}</h1>
+
+  <p>
+    <strong>Email:</strong> CS Unplugged is directed by Tim Bell.
+    You can <a href="mailto:tim.bell@canterbury.ac.nz">email him here</a>.
+  </p>
+
+  <p>
+    <strong>Twitter:</strong> <a href="https://twitter.com/UCCSEd">@UCCSEd</a>
+  </p>
+
+  <p>
+    <strong>Community Google Group:</strong> We have a <a href="https://groups.google.com/forum/#!forum/cs-unplugged-sharing">Google Group</a> you can join and talk about CS Unplugged.
+  </p>
+
+{% endblock %}

--- a/csunplugged/templates/general/people.html
+++ b/csunplugged/templates/general/people.html
@@ -1,0 +1,127 @@
+{% extends "general/about.html" %}
+{% load i18n %}
+{% load static %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  {% breadcrumb "People" "general:people" %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <h1>{% trans 'People' %}</h1>
+
+  <h2>Founders</h2>
+
+  <ul>
+    <li>Tim Bell - University of Canterbury</li>
+    <li>Ian Witten - University of Waikato</li>
+    <li>Michael Fellows - Charles Darwin University</li>
+  </ul>
+
+  <h2>Advisers</h2>
+
+  <ul>
+    <li>Craig Neville-Manning - Google</li>
+    <li>Peter J Denning - Computer Scientist</li>
+  </ul>
+
+  <h2>Current Team</h2>
+
+  <ul>
+    <li>Tim Bell - Founder &amp; Content Writer</li>
+    <li>Caitlin Duncan - Content Writer</li>
+    <li>Tracy Henderson - Content Writer</li>
+    <li>Behshid Ghorbani - Content Writer</li>
+    <li>Sarang Love Leehan - Founder &amp; Writer</li>
+    <li>Hayley van Waas - Technical Team</li>
+    <li>Hayden Jackson - Technical Team</li>
+    <li>Jack Morgan - Technical Team</li>
+  </ul>
+
+  <h2>Classic CS Unplugged</h2>
+
+  <h3>Contributors</h3>
+
+  <ul>
+    <li>Alfonso Rodriguez (USA)</li>
+    <li>Amitrajit Sarkar (New Zealand)</li>
+    <li>Anna Wingkvist (Sweden)</li>
+    <li>Anne Berry (France)</li>
+    <li>Benny Chor (Israel)</li>
+    <li>Bruce Webster (New Zealand)</li>
+    <li>Clara Eugenia</li>
+    <li>Constantine Mousafiris (Greece)</li>
+    <li>Faisal Hasan (Bangladesh)</li>
+    <li>Garza (Mexico)</li>
+    <li>Giovanni Michele Bianco (Italy)</li>
+    <li>Irina Derevianko (Russia)</li>
+    <li>Katharina Kranzdorf (Germany)</li>
+    <li>Long-Yuan Ya</li>
+    <li>Lorena Mendoza (United States)</li>
+    <li>Luciano Porto Barreto (Brazil)</li>
+    <li>Lukasz Nitschke (Poland)</li>
+    <li>Mohammed Obaid (New Zealand)</li>
+    <li>Mäxl Stege (Germany)</li>
+    <li>Paul Gibson (France)</li>
+    <li>Pawel Perekietka (Poland)</li>
+    <li>Professor Lee</li>
+    <li>Renzo Davoli Bologna (Italy)</li>
+    <li>Sertan Girgin (Turkey)</li>
+    <li>Shenglan Wang</li>
+    <li>Shimon Schocken (Israel)</li>
+    <li>Sook Kyoung Choi</li>
+    <li>SuYu (China)</li>
+    <li>Swami Manohar (India)</li>
+    <li>Theophanis Hatzigrivas (Greece)</li>
+    <li>Tom Verhoe</li>
+    <li>Yingchun Han (China)</li>
+  </ul>
+
+  <h3>Advisers</h3>
+
+  <ul>
+    <li>Alfred Thompson</li>
+    <li>Allen Tucker</li>
+    <li>Andy Seymour (USA)</li>
+    <li>Anna Charny (US)</li>
+    <li>Bengt Aspvall (Sweden)</li>
+    <li>David Vogt</li>
+    <li>Den Tsutom Wada (Japan)</li>
+    <li>Geri Lorway (Canada)</li>
+    <li>Harold Thimbleby (UK)</li>
+    <li>Lee Won Gyu</li>
+    <li>Len Wagner (USA)</li>
+    <li>Lenore Blum (USA)</li>
+    <li>Lynn Lambert (USA)</li>
+    <li>Mindy Hard (USA)</li>
+    <li>Pam Hagen (Canada)</li>
+    <li>Paul Gibson (France)</li>
+    <li>Peter Henderson</li>
+    <li>Rachel Kestenbaum (USA)</li>
+    <li>Rick Dipaolo (USA)</li>
+    <li>Robb Cutler (USA)</li>
+    <li>Sam Chung (USA)</li>
+    <li>Susumu Kanemune (Japan)</li>
+    <li>Todd Seymour (USA)</li>
+    <li>Tom Cortina (USA)</li>
+    <li>Xie Xie (China)  </li>
+  </ul>
+
+  <h3>Website</h3>
+
+  <ul>
+    <li>Sam Jarman (New Zealand)</li>
+    <li>Tim Bell (New Zealand)</li>
+    <li>Isaac Freeman (New Zealand)</li>
+    <li>Renzo Davoli (Italy)</li>
+    <li>Su Yu (China)</li>
+    <li>Murugesh and Bruce Webster (New Zealand)</li>
+  </ul>
+
+  <h2>Parrots</h2>
+
+  <ul>
+    <li>Arnold - Would like a cracker</li>
+  </ul>
+{% endblock %}

--- a/csunplugged/templates/general/principles.html
+++ b/csunplugged/templates/general/principles.html
@@ -1,0 +1,123 @@
+{% extends "general/about.html" %}
+{% load i18n %}
+{% load django_bootstrap_breadcrumbs %}
+
+{% block breadcrumbs %}
+  {{ block.super }}
+  {% breadcrumb "Principles" "general:principles" %}
+{% endblock breadcrumbs %}
+
+{% block content %}
+  <h1>{% trans 'Principles' %}</h1>
+
+  <p>
+    The primary goal of the Unplugged project is to promote Computer Science (and computing in general) to young people as an interesting, engaging, and intellectually stimulating discipline.
+    We want to capture people’s imagination and address common misconceptions about what it means to be a computer scientist.
+    We want to convey fundamentals that do not depend on particular software or systems, ideas that will still be fresh in 10 years.
+    We want to reach kids in elementary schools and provide supplementary material for university courses.
+    We want to tread where high-tech educational solutions are infeasible; to cross the divide between the information-rich and information-poor, between industrialized countries and the developing world.
+  </p>
+
+  <p>
+    There are many worthy projects for promoting computer science.
+    The main principles that distinguish the Unplugged activities are:
+  </p>
+
+  <h2>No Computers Required</h2>
+
+  <p>
+    The activities do not depend on computers.
+    This avoids confusing Computer Science with programming or learning application software, makes the activities available to those who aren’t able to or don’t want to work with computers, and skips the barrier of learning to program before being able to explore ideas.
+    It also provides physical, kinaesthetic experiences as part of learning computing, which can be a welcome break from sitting in front of a screen.
+    For example, the parity magic trick is a card game that happens to use the same principle as error correction in computer memory.
+    Unplugged isn’t a completely Luddite approach – we do exploit the internet and other computing facilities to share and develop the activities, and we hope that students will have to opportunity to learn to program so that they can put wheels on the ideas they have been exploring.
+  </p>
+
+  <h2>Real Computer Science</h2>
+
+  <p>
+    Unplugged presents fundamental concepts in Computer Science such as algorithms, artificial intelligence, graphics, information theory, human computer interfaces, programming languages, and so on.
+    We want to emphasize that programming is a means, not an end.
+    Wikipedia provides a definition of Computer Science, and Peter Denning’s Great Principles project provides a more detailed analysis of the topics it covers.
+  </p>
+
+  <h2>Learning by doing</h2>
+
+  <p>
+    The activities tend to be kinaesthetic, often on a large scale and involving team work.
+    For example, the Sorting Network activity has teams of six running through a network drawn on the ground.
+    The activities tend to allow students to discover answers for themselves, rather than just being given solutions or algorithms to follow; that is, a constructivist approach is encouraged (where the teacher uses the scaffolding provided by Unplugged to ask questions that lead them to discover the knowledge themselves), as we want students to realize that they are capable of finding solutions to problems on their own, rather than being given a solution to apply to the problem.
+    For example, students don’t really need to be able to convert numbers to binary, but it is valuable for them to discover the patterns such as the doubling value of bits, patterns when you count in binary, and how the range increases exponentially as you add bits.
+  </p>
+
+  <h2>Fun</h2>
+
+  <p>
+    The activities are fun and engaging, not just busy-work for the sake of it.
+    Usually the explanations are quite brief – the teacher lays out the materials and a few rules, and the students follow the challenge from there.
+    There are puzzles, challenges, competitions, problem solving and humour.
+    Unplugged activities should leave students with a sense of genuine achievement.
+    There is often a strong sense of story in the activities; problems are presented as part of a story rather than as an abstract mathematical challenge.
+    Children are more interested in pirates than privacy, and absurd fictitious stories can be more memorable than compelling business applications.
+  </p>
+
+  <h2>No specialised equipment</h2>
+
+  <p>
+    The activities are low cost, using equipment commonly found in classrooms or stationery stores.
+    Most require only paper and pencil, and perhaps cards, string, chalk, whiteboard markers, balls or similar items.
+  </p>
+
+  <h2>Variations encouraged</h2>
+
+  <p>
+    Unplugged is published under a Creative Commons licence, which permits free sharing (with acknowledgement).
+    Variations, adaptations and extensions are encouraged.
+    This also allows local publishing arrangements to take account of the kind of packaging that would make the material more accessible to local educational practitioners.
+  </p>
+
+  <p>
+    Two specific situations that we get asked about are:
+  </p>
+
+  <ul>
+    <li>
+      <strong>For-profit classes (e.g. clubs with a subscription fee):</strong> It is fine to charge a fee for people to attend classes that you're running that uses this material.
+    </li>
+    <li>
+      <strong>Selling packs of support material (such as pre-printed cards):</strong> It is fine to do this.
+      We hope that you'll do it for a reasonable price, and it's even better if you can get someone to sponsor you so that you can give it away to educators, but the license allows you to set your own price.
+    </li>
+  </ul>
+
+  <h2>For everyone</h2>
+
+  <p>
+    The programme is strongly international – we encourage variations that are relevant to local cultures (for example, some activities that require a large playground can be changed to a board game for schools that have very little open space; others use contexts that might not be familiar to students in a different culture).
+    Translators should try the activities locally and involve teachers.
+    It is better to adapt activities rather than translate them faithfully to something that would be less meaningful in the local culture.
+    The activities are intended to be inclusive.
+  </p>
+
+  <h2>Co-operative</h2>
+
+  <p>
+    We encourage co-operation, communication and problem solving.
+    Competition can also be effective if it is used appropriately, especially between teams rather than individuals, but having students working cooperatively is a great way to learn about problem solving.
+  </p>
+
+  <h2>Stand-alone Activities</h2>
+
+  <p>
+    As much as possible, the activities are stand-alone modules that can be used independently of each other, so that they can be used for enrichment in curricula or for outreach on their own rather than having to be used as a series.
+    The ones that have been presented as lesson plans will sometimes require a series of lessons to be followed, but we will indicate if particular preparation is required.
+  </p>
+
+  <h2>Resilient</h2>
+
+  <p>
+    The activities are resilient to errors made by students; they should not depend on getting many difficult steps exactly right, and minor mistakes should not prevent participants from understanding the principles.
+    The instructions are usually just one or two rules and a goal that can be expressed in a single sentence (e.g. “Each card is either fully visible or not; how can you display exactly 11 dots?”, or “We need to get from any house to any other house; what is the smallest number of paving stones that make this possible”).
+  </p>
+
+{% endblock %}


### PR DESCRIPTION
Adds the following basic pages:

- About
- Contact
- People
- Principles

All will need revisions before `2.0.0` release, this is basic starter content.