### PR TITLE
Issue/183 PEP8 fixes and simplify error string handling

### DIFF
--- a/csunplugged/utils/errors/CouldNotFindConfigFileError.py
+++ b/csunplugged/utils/errors/CouldNotFindConfigFileError.py
@@ -1,5 +1,7 @@
 from .Error import Error
 
+ERROR_MESSAGE = "\nCould not find config file.\n"
+
 
 class CouldNotFindConfigFileError(Error):
     '''Raised when a yaml file cannot be found
@@ -12,4 +14,4 @@ class CouldNotFindConfigFileError(Error):
         self.config_file_path = config_file_path
 
     def __str__(self):
-        return self.base_message.format(filename=self.config_file_path) + self.missing_file_suggestions
+        return self.base_message.format(filename=self.config_file_path) + ERROR_MESSAGE + self.missing_file_suggestions

--- a/csunplugged/utils/errors/CouldNotFindConfigFileError.py
+++ b/csunplugged/utils/errors/CouldNotFindConfigFileError.py
@@ -1,16 +1,15 @@
 from .Error import Error
 
+
 class CouldNotFindConfigFileError(Error):
     '''Raised when a yaml file cannot be found
     '''
-    
+
     def __init__(self, config_file_path):
-    	'''
-    	'''
-    	super().__init__()
-    	self.config_file_path = config_file_path
+        '''
+        '''
+        super().__init__()
+        self.config_file_path = config_file_path
 
     def __str__(self):
-    	missing_config_file_message = ''
-    	return self.base_message.format(self.config_file_path) + \
-    	    self.missing_file_suggestions
+        return self.base_message.format(filename=self.config_file_path) + self.missing_file_suggestions

--- a/csunplugged/utils/errors/CouldNotFindImageError.py
+++ b/csunplugged/utils/errors/CouldNotFindImageError.py
@@ -1,5 +1,7 @@
 from .Error import Error
 
+ERROR_MESSAGE = "\nCould not find image.\n"
+
 
 class CouldNotFindImageError(Error):
     '''Raised when an image cannot be found in static/ directory
@@ -15,4 +17,4 @@ class CouldNotFindImageError(Error):
     def __str__(self):
         base_message = self.base_message.format(filename=self.image_path)
         reference = self.reference_message.format(reference=self.reference_file_path)
-        return base_message + reference + self.missing_file_suggestions
+        return base_message + reference + ERROR_MESSAGE +  self.missing_file_suggestions

--- a/csunplugged/utils/errors/CouldNotFindImageError.py
+++ b/csunplugged/utils/errors/CouldNotFindImageError.py
@@ -1,5 +1,6 @@
 from .Error import Error
 
+
 class CouldNotFindImageError(Error):
     '''Raised when an image cannot be found in static/ directory
     '''
@@ -12,6 +13,6 @@ class CouldNotFindImageError(Error):
         self.reference_file_path = reference_file_path
 
     def __str__(self):
-        self.reference = self.reference_message.format(self.reference_file_path)
-        return self.base_message.format(self.image_path) + \
-            self.reference + self.missing_file_suggestions
+        base_message = self.base_message.format(filename=self.image_path)
+        reference = self.reference_message.format(reference=self.reference_file_path)
+        return base_message + reference + self.missing_file_suggestions

--- a/csunplugged/utils/errors/CouldNotFindMarkdownFileError.py
+++ b/csunplugged/utils/errors/CouldNotFindMarkdownFileError.py
@@ -1,5 +1,7 @@
 from .Error import Error
 
+ERROR_MESSAGE = "\nCould not find Markdown file.\n"
+
 
 class CouldNotFindMarkdownFileError(Error):
     '''Raised when no matching Markdown file can be found in the given path
@@ -15,4 +17,4 @@ class CouldNotFindMarkdownFileError(Error):
     def __str__(self):
         base_message = self.base_message.format(filename=self.md_file_path)
         reference = self.reference_message.format(reference=self.config_file_path)
-        return base_message + reference + self.missing_file_suggestions
+        return base_message + reference + ERROR_MESSAGE + self.missing_file_suggestions

--- a/csunplugged/utils/errors/CouldNotFindMarkdownFileError.py
+++ b/csunplugged/utils/errors/CouldNotFindMarkdownFileError.py
@@ -1,9 +1,10 @@
 from .Error import Error
 
+
 class CouldNotFindMarkdownFileError(Error):
     '''Raised when no matching Markdown file can be found in the given path
     '''
-    
+
     def __init__(self, md_file_path, config_file_path):
         '''
         '''
@@ -12,6 +13,6 @@ class CouldNotFindMarkdownFileError(Error):
         self.config_file_path = config_file_path
 
     def __str__(self):
-        self.reference = self.reference_message.format(self.config_file_path)
-        return self.base_message.format(self.md_file_path) + \
-            self.reference + self.missing_file_suggestions
+        base_message = self.base_message.format(filename=self.md_file_path)
+        reference = self.reference_message.format(reference=self.config_file_path)
+        return base_message + reference + self.missing_file_suggestions

--- a/csunplugged/utils/errors/EmptyConfigFileError.py
+++ b/csunplugged/utils/errors/EmptyConfigFileError.py
@@ -1,6 +1,6 @@
 from .Error import Error
 
-ERROR_MESSAGE = "A config file cannot be empty.\n"
+ERROR_MESSAGE = "\nA config file cannot be empty.\n"
 
 
 class EmptyConfigFileError(Error):

--- a/csunplugged/utils/errors/EmptyConfigFileError.py
+++ b/csunplugged/utils/errors/EmptyConfigFileError.py
@@ -1,15 +1,17 @@
 from .Error import Error
 
+ERROR_MESSAGE = "A config file cannot be empty.\n"
+
+
 class EmptyConfigFileError(Error):
     '''Raised when there is no content in a config file
     '''
-    
+
     def __init__(self, yaml_file_path):
-    	'''
-    	'''
-    	super().__init__()
-    	self.yaml_file_path = yaml_file_path
+        '''
+        '''
+        super().__init__()
+        self.yaml_file_path = yaml_file_path
 
     def __str__(self):
-    	empty_file_message = '\nA config file cannot be empty'
-    	return self.base_message.format(self.yaml_file_path) + empty_file_message
+        return self.base_message.format(filename=self.yaml_file_path) + ERROR_MESSAGE

--- a/csunplugged/utils/errors/EmptyMarkdownFileError.py
+++ b/csunplugged/utils/errors/EmptyMarkdownFileError.py
@@ -1,17 +1,22 @@
 from .Error import Error
 
+ERROR_MESSAGE = """
+The file contains no content.
+
+Note: A file containting a title and no other content is
+also considered to be empty.
+"""
+
+
 class EmptyMarkdownFileError(Error):
     '''Raised when there is no content (excluding title) in a Markdown File
     '''
-    
+
     def __init__(self, md_file_path):
-    	'''
-    	'''
-    	super().__init__()
-    	self.md_file_path = md_file_path
+        '''
+        '''
+        super().__init__()
+        self.md_file_path = md_file_path
 
     def __str__(self):
-    	empty_file_message = '\nThe file contains no content. ' + \
-    	    '\n  Note: A file containting a title and no other content is ' + \
-    	    'also considered to be empty.'
-    	return self.base_message.format(self.md_file_path) + empty_file_message
+        return self.base_message.format(filename=self.md_file_path) + ERROR_MESSAGE

--- a/csunplugged/utils/errors/Error.py
+++ b/csunplugged/utils/errors/Error.py
@@ -1,15 +1,18 @@
+ERROR_TITLE_TEMPLATE = "****************************ERROR****************************\n"
+ERROR_FILENAME_TEMPLATE = "File: {filename}\n"
+ERROR_REFERENCE_TEMPLATE = "Referenced in: {reference}\n"
+ERROR_SUGGESTIONS_TEMPLATE = """
+  - Did you spell the name of the file correctly?
+  - Does the file exist?
+  - Is the file saved in the correct directory?
+"""
+
+
 class Error(Exception):
     '''Base class for Errors.
     (Exceptions from external sources such as inputs).
     '''
     def __init__(self):
-        self.base_message = '\n' + \
-            '\n****************************ERROR****************************' + \
-            '\nFile: {}'
-            
-        self.reference_message = '\nReferenced in: {}'
-
-        self.missing_file_suggestions = '' + \
-            '\n  - Did you spell the name of the file correctly?' + \
-            '\n  - Does the file exist?' + \
-            '\n  - Is the file saved in the correct directory?'
+        self.base_message = ERROR_TITLE_TEMPLATE + ERROR_FILENAME_TEMPLATE
+        self.reference_message = ERROR_REFERENCE_TEMPLATE
+        self.missing_file_suggestions = ERROR_SUGGESTIONS_TEMPLATE

--- a/csunplugged/utils/errors/InvalidConfigFileError.py
+++ b/csunplugged/utils/errors/InvalidConfigFileError.py
@@ -1,18 +1,24 @@
 from .Error import Error
 
+ERROR_MESSAGE = """
+Invalid configuration file.
+
+Options:
+  - Does the file match the expected layout?
+  - Does the file contain at least one key:value pair?
+  - Is the syntax correct? (are you missing a colon somewhere?)
+"""
+
+
 class InvalidConfigFileError(Error):
     '''Raised when there is no content in a config file
     '''
-    
+
     def __init__(self, yaml_file_path):
-    	'''
-    	'''
-    	super().__init__()
-    	self.yaml_file_path = yaml_file_path
+        '''
+        '''
+        super().__init__()
+        self.yaml_file_path = yaml_file_path
 
     def __str__(self):
-    	invalid_message = '\nInvalid configuration file.' + \
-            '\n  - Does the file match the expected layout?' + \
-            '\n  - Does the file contain at least one key:value pair?' + \
-            '\n  - Is the syntax correct? (are you missing a colon somewhere?...)'
-    	return self.base_message.format(self.yaml_file_path) + invalid_message
+        return self.base_message.format(filename=self.yaml_file_path) + ERROR_MESSAGE

--- a/csunplugged/utils/errors/KeyNotFoundError.py
+++ b/csunplugged/utils/errors/KeyNotFoundError.py
@@ -1,19 +1,26 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+Key: {key}
+"{key}" did not match any {field}
+
+Options:
+  - Did you spell the name of the key correctly?
+  - Does the key exist?
+"""
+
+
 class KeyNotFoundError(Error):
     '''Raised when configuration file specifies a key that does not exist.
     '''
-    
+
     def __init__(self, config_file_path, key, field):
-    	super().__init__()
-    	self.config_file_path = config_file_path
-    	self.key = key
-    	self.field = field
+        super().__init__()
+        self.config_file_path = config_file_path
+        self.key = key
+        self.field = field
 
     def __str__(self):
-    	key_not_found_message = '\nKey: {}'.format(self.key) + \
-    		'\n"{}" did not match any {}.'.format(self.key, self.field) + \
-    	    '\n  - Did you spell the name of the key correctly?' + \
-            '\n  - Does the key exist?'
-    	return self.base_message.format(self.config_file_path) + \
-    	    key_not_found_message
+        base_message = self.base_message.format(filename=self.config_file_path)
+        error_message = ERROR_MESSAGE_TEMPLATE.format(key=self.key, field=self.field)
+        return base_message + error_message

--- a/csunplugged/utils/errors/MissingCurriculumArea.py
+++ b/csunplugged/utils/errors/MissingCurriculumArea.py
@@ -1,5 +1,16 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+Could not find Curriculum Area: {area}
+
+Options:
+  - Check the curriculum-areas.yaml file for the list of available
+    Curriculum Areas
+  - Check you have included the curriculum_areas.yaml file in
+    structure.yaml
+"""
+
+
 class MissingCurriculumArea(Error):
     """Exception raised when no learning objective matches a given key.
     """
@@ -8,12 +19,6 @@ class MissingCurriculumArea(Error):
         super().__init__()
         self.loader = loader
         self.curriculum_area_name = curriculum_area_name
-        
+
     def __str__(self):
-        return '\n***************ERROR***************\n' + \
-        'Could not find Curriculum Area: {}\n'.format(self.curriculum_area_name) + \
-        'Options:\n' + \
-            '- Check the curriculum_areas.yaml file for the list of available ' + \
-            'Curriculum Areas\n' + \
-            '- Check you have included the curriculum_areas.yaml file in ' + \
-            'structure.yaml'
+        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(area=self.curriculum_area_name)

--- a/csunplugged/utils/errors/MissingCurriculumArea.py
+++ b/csunplugged/utils/errors/MissingCurriculumArea.py
@@ -15,10 +15,11 @@ class MissingCurriculumArea(Error):
     """Exception raised when no learning objective matches a given key.
     """
 
-    def __init__(self, loader, curriculum_area_name):
+    def __init__(self, filename, curriculum_area_name):
         super().__init__()
-        self.loader = loader
+        self.filename = filename
         self.curriculum_area_name = curriculum_area_name
 
     def __str__(self):
-        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(area=self.curriculum_area_name)
+        base_message = self.base_message.format(filename=self.filename)
+        return base_message + ERROR_MESSAGE_TEMPLATE.format(area=self.curriculum_area_name)

--- a/csunplugged/utils/errors/MissingLanguageImplementation.py
+++ b/csunplugged/utils/errors/MissingLanguageImplementation.py
@@ -15,10 +15,11 @@ class MissingLanguageImplementation(Error):
     """Exception raised when no learning objective matches a given key.
     """
 
-    def __init__(self, loader, language):
+    def __init__(self, filename, language):
         super().__init__()
-        self.loader = loader
+        self.filename = filename
         self.language = language
 
     def __str__(self):
-        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(language=self.language)
+        base_message = self.base_message.format(filename=self.filename)
+        return base_message + ERROR_MESSAGE_TEMPLATE.format(language=self.language)

--- a/csunplugged/utils/errors/MissingLanguageImplementation.py
+++ b/csunplugged/utils/errors/MissingLanguageImplementation.py
@@ -1,5 +1,16 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+Could not find Language Implementation: {language}
+
+Options:
+  - Check the programming-exercises-structure.yaml file for the list of
+    available programming languages
+  - Check you have included the programming-exercises-structure.yaml
+    file in structure.yaml
+"""
+
+
 class MissingLanguageImplementation(Error):
     """Exception raised when no learning objective matches a given key.
     """
@@ -10,10 +21,4 @@ class MissingLanguageImplementation(Error):
         self.language = language
 
     def __str__(self):
-        return '\n***************ERROR***************\n' + \
-        'Could not find Language Implementation: {}\n'.format(self.language) + \
-        'Options:\n' + \
-            '- Check the programming-exercises-structure.yaml file for the list of ' + \
-            'available programming languages\n' + \
-            '- Check you have included the programming-exercises-structure.yaml ' + \
-            'file in structure.yaml'
+        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(language=self.language)

--- a/csunplugged/utils/errors/MissingLearningObjective.py
+++ b/csunplugged/utils/errors/MissingLearningObjective.py
@@ -1,5 +1,16 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+Could not find Learning Outcome: {slug}
+
+Options:
+  - Check the learning-outcomes.yaml file for the list of available
+    Learning Outcome key-value pairs.
+  - Check you have included the learning-outcomes.yaml file in
+    structure.yaml
+"""
+
+
 class MissingLearningObjective(Error):
     """Exception raised when no learning objective matches a given key.
     """
@@ -10,10 +21,4 @@ class MissingLearningObjective(Error):
         self.learning_outcome_slug = learning_outcome_slug
 
     def __str__(self):
-        return '\n***************ERROR***************\n' + \
-        'Could not find Learning Outcome: {}\n'.format(self.learning_outcome_slug) + \
-        'Options:\n' + \
-            '- Check the learning-outcomes.yaml file for the list of available ' + \
-            'Learning Outcome key-value pairs\n' + \
-            '- Check you have included the learning-outcomes.yaml file in ' + \
-            'structure.yaml'
+        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(slug=self.learning_outcome_slug)

--- a/csunplugged/utils/errors/MissingLearningObjective.py
+++ b/csunplugged/utils/errors/MissingLearningObjective.py
@@ -15,10 +15,11 @@ class MissingLearningObjective(Error):
     """Exception raised when no learning objective matches a given key.
     """
 
-    def __init__(self, loader, learning_outcome_slug):
+    def __init__(self, filename, learning_outcome_slug):
         super().__init__()
-        self.loader = loader
+        self.filename = filename
         self.learning_outcome_slug = learning_outcome_slug
 
     def __str__(self):
-        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(slug=self.learning_outcome_slug)
+        base_message = self.base_message.format(filename=self.filename)
+        return base_message + ERROR_MESSAGE_TEMPLATE.format(slug=self.learning_outcome_slug)

--- a/csunplugged/utils/errors/MissingProgrammingDifficulty.py
+++ b/csunplugged/utils/errors/MissingProgrammingDifficulty.py
@@ -15,10 +15,11 @@ class MissingProgrammingDifficulty(Error):
     """Exception raised when no learning objective matches a given key.
     """
 
-    def __init__(self, loader, programming_difficulty):
+    def __init__(self, filename, programming_difficulty):
         super().__init__()
-        self.loader = loader
+        self.filename = filename
         self.programming_difficulty = programming_difficulty
 
     def __str__(self):
-        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(difficulty=self.programming_difficulty)
+        base_message = self.base_message.format(filename=self.filename)
+        return base_message + ERROR_MESSAGE_TEMPLATE.format(difficulty=self.programming_difficulty)

--- a/csunplugged/utils/errors/MissingProgrammingDifficulty.py
+++ b/csunplugged/utils/errors/MissingProgrammingDifficulty.py
@@ -1,5 +1,16 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+Could not find Programming Difficulty: {difficulty}
+
+Options:
+  - Check the programming-exercises-structure.yaml file for the list of
+    available difficulty levels
+  - Check you have included the programming-exercises-structure.yaml
+    file in structure.yaml
+"""
+
+
 class MissingProgrammingDifficulty(Error):
     """Exception raised when no learning objective matches a given key.
     """
@@ -10,11 +21,4 @@ class MissingProgrammingDifficulty(Error):
         self.programming_difficulty = programming_difficulty
 
     def __str__(self):
-        return '\n***************ERROR***************\n' + \
-        'Could not find Programming Difficulty: {}\n'.format(
-            self.programming_difficulty) + \
-        'Options:\n' + \
-            '- Check the programming-exercises-structure.yaml file for the list of ' + \
-            'available difficulty levels\n' + \
-            '- Check you have included the programming-exercises-structure.yaml ' + \
-            'file in structure.yaml'
+        return self.base_message + ERROR_MESSAGE_TEMPLATE.format(difficulty=self.programming_difficulty)

--- a/csunplugged/utils/errors/MissingRequiredFieldError.py
+++ b/csunplugged/utils/errors/MissingRequiredFieldError.py
@@ -1,24 +1,31 @@
 from .Error import Error
 
+ERROR_MESSAGE_TEMPLATE = """
+A {model} requires the following fields:
+{fields}
+
+One or more of these fields are missing.
+  - Are all the field names spelt correctly?
+  - Do all fields have values?
+"""
+
+
 class MissingRequiredFieldError(Error):
     '''Raised when a required field is missing from a yaml file
     '''
-    
+
     def __init__(self, config_file_path, required_fields, model):
-    	super().__init__()
-    	self.config_file_path = config_file_path
-    	self.required_fields = required_fields
-    	self.model = model
+        super().__init__()
+        self.config_file_path = config_file_path
+        self.required_fields = required_fields
+        self.model = model
 
     def __str__(self):
-    	fields = ''
-    	for field in self.required_fields:
-    		fields += '\n  - {}'.format(str(field))
-    	missing_field_message = '' + \
-    	    '\nA {} requires the following fields:'.format(self.model) + \
-    	    fields + \
-    	    '\nOne or more of these fields are missing.' + \
-    	    '\n  - Are all the field names spelt correctly?' + \
-    	    '\n  - Do all fields have values?'  	    
-    	return self.base_message.format(self.config_file_path) + \
-    	    missing_field_message
+        fields = ''
+        for field in self.required_fields:
+            fields += '  - {field}\n'.format(field=str(field))
+        missing_field_message = ERROR_MESSAGE_TEMPLATE.format(
+            model=self.model,
+            fields=fields
+        )
+        return self.base_message.format(filename=self.config_file_path) + missing_field_message

--- a/csunplugged/utils/errors/MissingRequiredFieldError.py
+++ b/csunplugged/utils/errors/MissingRequiredFieldError.py
@@ -3,7 +3,6 @@ from .Error import Error
 ERROR_MESSAGE_TEMPLATE = """
 A {model} requires the following fields:
 {fields}
-
 One or more of these fields are missing.
   - Are all the field names spelt correctly?
   - Do all fields have values?

--- a/csunplugged/utils/errors/NoHeadingFoundInMarkdownFileError.py
+++ b/csunplugged/utils/errors/NoHeadingFoundInMarkdownFileError.py
@@ -1,6 +1,6 @@
 from .Error import Error
 
-ERROR_MESSAGE = "The file does not contain a heading.\n"
+ERROR_MESSAGE = "\nThe file does not contain a heading.\n"
 
 
 class NoHeadingFoundInMarkdownFileError(Error):

--- a/csunplugged/utils/errors/NoHeadingFoundInMarkdownFileError.py
+++ b/csunplugged/utils/errors/NoHeadingFoundInMarkdownFileError.py
@@ -1,14 +1,15 @@
 from .Error import Error
 
+ERROR_MESSAGE = "The file does not contain a heading.\n"
+
+
 class NoHeadingFoundInMarkdownFileError(Error):
     '''Raised when a title cannot be found in a Markdown File
     '''
-    
+
     def __init__(self, md_file_path):
-    	super().__init__()
-    	self.md_file_path = md_file_path
+        super().__init__()
+        self.md_file_path = md_file_path
 
     def __str__(self):
-    	no_heading_message = '\nThe file does not contain a heading.'
-    	return self.base_message.format(self.md_file_path) + no_heading_message
-
+        return self.base_message.format(filename=self.md_file_path) + ERROR_MESSAGE


### PR DESCRIPTION
This fixes all but two PEP8 fixes (so Travis CI will show fail), and changes the ways strings are managed in custom exceptions.

@hayleyavw: The Learning Outcomes loader is broken, the wrong variables are used in the `__init__` method so rather than fixing it, I'll leave it to you (as the rest of it might need changing too). We haven't encountered this yet as we don't use it.

I also haven't gotten around to testing the output of these errors, I'll get to that later tonight.