### PR TITLE
Remove while loop waiting for Nginx system to boot

### DIFF
--- a/csu
+++ b/csu
@@ -42,11 +42,6 @@ function helpmenu {
 function start {
   echo "Creating systems..."
   docker-compose up -d
-  # Wait until website is ready (therefore Postgres is also ready)
-  echo "Waiting until all systems are ready... (takes roughly 10 to 20 seconds)"
-  until $(curl --output /dev/null --silent --head --fail http://localhost); do
-    sleep 0.25
-  done
   # Run helper functions
   update
   # Alert user that system is ready


### PR DESCRIPTION
This seems to fix the problem of infinite loops since the loop is now completely gone. The system runs without waiting, I think because the first command requires Nginx to run.

I'm still unsure about parts of the script, but that would require someone knowledge of Bash to look it over.