### PR TITLE
Add custom HTML for panel (fixes #222)

### DIFF
--- a/csunplugged/utils/custom_converter_templates/panel.html
+++ b/csunplugged/utils/custom_converter_templates/panel.html
@@ -1,0 +1,9 @@
+<details{% if expanded == 'true'%} open{% endif %}>
+  <summary>
+    <strong>{{ title }}{% if subtitle %}:</strong> {{ subtitle }}{% else %}</strong>{% endif %}
+  </summary>
+
+  {% autoescape false -%}
+  {{ content }}
+  {%- endautoescape %}
+</details>


### PR DESCRIPTION
This urgent fix provides basic HTML for rendering panels, a new issue will need to be created though for creating a proper panel.

Caveats:
- No IE/Edge support
- No styling for panel types
- No transition animations