### PR TITLE
Add test to check documentation builds correctly (fixes #215)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ script:
   - ./csu test
   - ./csu test_backwards
   - ./csu style
+  - ./csu docs
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/csu
+++ b/csu
@@ -26,6 +26,7 @@ function helpmenu {
   printf "Available commands:\n"
   printf "   build             Build or rebuild Docker images\n"
   printf "   clean             Deletes dangling Docker images\n"
+  printf "   docs              Generates the documentation\n"
   printf "   end               Stop development environment\n"
   printf "   help              View help menu\n"
   printf "   logs              View logs\n"
@@ -124,6 +125,15 @@ function test_suite_backwards {
   fi
 }
 
+# Generates the documentation (with warnings as errors)
+function documentation {
+  echo "Removing any existing documentation..."
+  docker-compose run django rm -rf /cs-unplugged/docs/build/
+  docker-compose run django mkdir /cs-unplugged/docs/build/
+  echo "Creating documentation..."
+  docker-compose run django /docker_venv/bin/sphinx-build -W /cs-unplugged/docs/source/ /cs-unplugged/docs/build/
+}
+
 # Delete all untagged dangling Docker images
 function clean {
   docker rmi $(docker images -f "dangling=true" -q)
@@ -157,6 +167,10 @@ do
       ;;
     clean | -c)
       clean
+      exit
+      ;;
+    docs | -d)
+      documentation
       exit
       ;;
     end | -e)

--- a/csu
+++ b/csu
@@ -44,17 +44,18 @@ function helpmenu {
 
 # Start development environment
 function start {
-  echo "Creating systems..."
+  printf "Creating systems...\n"
   docker-compose up -d
+  printf "\n"
   # Run helper functions
   update
   # Alert user that system is ready
-  printf "${GREEN}Systems are ready!${NC}\n"
+  printf "\n${GREEN}Systems are ready!${NC}\n"
 }
 
 # Stop development environment
 function end {
-  echo "Stopping systems... (takes roughly 10 to 20 seconds)"
+  printf "Stopping systems... (takes roughly 10 to 20 seconds)\n"
   docker-compose down
 }
 
@@ -62,10 +63,10 @@ function end {
 function update {
   static
 
-  echo "Apply database migrations..."
+  printf "\nApply database migrations...\n"
   docker-compose run django /docker_venv/bin/python3 ./manage.py migrate
 
-  echo "Loading topics content..."
+  printf "\nLoading topics content...\n"
   docker-compose run django /docker_venv/bin/python3 ./manage.py updatedata
 
   static_scratch
@@ -74,25 +75,25 @@ function update {
 
 # Build Docker images
 function build {
-  echo "Building Docker images..."
+  printf "Building Docker images...\n"
   docker-compose build
 }
 
 # Build static files
 function static {
-  echo "Building static files..."
+  printf "Building static files...\n"
   docker-compose run nginx gulp build
 }
 
 # Build scratch static files
 function static_scratch {
-  echo "Building scratch images..."
+  printf "Building scratch images...\n"
   docker-compose run nginx gulp scratch
 }
 
 # Collecting static files
 function collect_static {
-  echo "Collecting static files..."
+  printf "\nCollecting static files..."
   docker-compose run django /docker_venv/bin/python3 ./manage.py collectstatic --no-input
 }
 
@@ -103,22 +104,22 @@ function shell {
 
 # Run style checks
 function style {
-  echo "Running PEP8 style checker..."
+  printf "Running PEP8 style checker...\n"
   docker-compose run -w /cs-unplugged/ django /docker_venv/bin/flake8
-  echo "Running Python docstring checker..."
+  printf "\nRunning Python docstring checker...\n"
   docker-compose run -w /cs-unplugged/ django /docker_venv/bin/pydocstyle --count --explain
 }
 
 # Run test suite with coverage checking
 function test_suite {
-  echo "Running test suite..."
+  printf "Running test suite...\n"
   docker-compose run django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --pattern "test_*.py" -v 3
   docker-compose run django /docker_venv/bin/coverage report
 }
 
 # Run test suite backwards for CI testing
 function test_suite_backwards {
-  echo "Running test suite backwards..."
+  printf "Running test suite backwards...\n"
   if [ "$TRAVIS_PULL_REQUEST" != "false" ]
   then
     docker-compose run django /docker_venv/bin/python3 ./manage.py test --pattern "test_*.py" --reverse -v 0
@@ -127,10 +128,10 @@ function test_suite_backwards {
 
 # Generates the documentation (with warnings as errors)
 function documentation {
-  echo "Removing any existing documentation..."
+  printf "Removing any existing documentation...\n"
   docker-compose run django rm -rf /cs-unplugged/docs/build/
   docker-compose run django mkdir /cs-unplugged/docs/build/
-  echo "Creating documentation..."
+  printf "\nCreating documentation...\n"
   docker-compose run django /docker_venv/bin/sphinx-build -W /cs-unplugged/docs/source/ /cs-unplugged/docs/build/
 }
 
@@ -191,7 +192,7 @@ do
       ;;
     start | -s)
       start
-      echo "Open your preferred web browser to the URL 'localhost'"
+      printf "Open your preferred web browser to the URL 'localhost'\n"
       exit
       ;;
     static)


### PR DESCRIPTION
## Changes

- Add `csu docs` command for building documentation.
  - All warnings are treated as errors.
- Adds `csu docs` to Travis checks.

Fixes #215.