### PR TITLE
Add code coverage (fixes #173)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - ./csu style
 
 after_script:
-  - docker-compose run django bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash)
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - ./csu style
 
 after_script:
-  - docker-compose run django /docker_venv/bin/codecov
+  - docker-compose run django bash <(curl -s https://codecov.io/bash)
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,9 @@ script:
   - ./csu test_backwards
   - ./csu style
 
+after_script:
+  - docker-compose run django /docker_venv/bin/codecov
+
 # Stop email notifications but post to organisation Slack channel
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - ./csu style
 
 after_script:
-  - bash <(curl -s https://codecov.io/bash)
+  - bash <(curl -s https://codecov.io/bash) -f ./csunplugged/.coverage
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
   - ./csu style
 
 after_script:
-  - bash <(curl -s https://codecov.io/bash) -f ./csunplugged/.coverage
+  - bash <(curl -s https://codecov.io/bash)
 
 # Stop email notifications but post to organisation Slack channel
 notifications:

--- a/csu
+++ b/csu
@@ -112,7 +112,8 @@ function style {
 function test_suite {
   echo "Running test suite..."
   docker-compose run django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --pattern "test_*.py" -v 3
-  docker-compose run django /docker_venv/bin/coverage report
+  docker-compose run django /docker_venv/bin/coverage xml -i
+  docker-compose run django /docker_venv/bin/coverage report -m --skip-covered
 }
 
 # Run test suite backwards for CI testing

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,6 +6,7 @@ pydocstyle==2.0.0
 
 #Coverage Tools
 coverage==4.3.4
+codecov=2.0.7
 
 # Mock Database
 model_mommy==1.3.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,6 @@ pydocstyle==2.0.0
 
 #Coverage Tools
 coverage==4.3.4
-codecov==2.0.7
 
 # Mock Database
 model_mommy==1.3.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,7 +6,7 @@ pydocstyle==2.0.0
 
 #Coverage Tools
 coverage==4.3.4
-codecov=2.0.7
+codecov==2.0.7
 
 # Mock Database
 model_mommy==1.3.2


### PR DESCRIPTION
Adds code coverage available on Codecov. Reason for failing build is due to no coverage in `develop` yet.

Coverage off this PR: https://codecov.io/gh/uccser/cs-unplugged/tree/37c86870b23356c1fd51729465be4c4d954191ec/csunplugged