### PR TITLE
Add greater style difference between headings (fixes #271)

### DIFF
--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -19,15 +19,32 @@ img {
   }
 }
 
+h1 {
+  color: $red;
+}
+h2 {
+  color: $purple;
+}
+h3 {
+  color: $green;
+}
+h4,
+h5,
+h6 {
+  color: $gray;
+}
+
 h1,
 h2,
-h3 {
-  color: #e33333;
-  margin-top: 1.5rem;
+h3,
+h4,
+h5,
+h6 {
+  border-bottom: 2px solid $gray-lighter;
+}
 
-  span.subtitle {
-    color: #888;
-  }
+.subtitle {
+  color: $gray-light;
 }
 
 input[type="text"].long-text-field {


### PR DESCRIPTION
The colours for `h1`, `h2`, and `h3` are not considered final, but are different enough to continue web design. I didn't use dashed underline as this style will be used a lot else on the website (panels, boxed text, etc) so I wanted the headers to use a unique style.

Example of new headings:
![image](https://cloud.githubusercontent.com/assets/8001048/25842102/dc8ad37e-34f6-11e7-869c-e508a551c96d.png)
