### PR TITLE
Change loader logs to output as they go (fixes #423)

### DIFF
--- a/csunplugged/resources/management/commands/_ResourcesLoader.py
+++ b/csunplugged/resources/management/commands/_ResourcesLoader.py
@@ -57,5 +57,4 @@ class ResourcesLoader(BaseLoader):
             resource.save()
 
             self.log("Added Resource: {}".format(resource.name))
-
-        self.print_load_log()
+        self.log("All resources loaded!\n")

--- a/csunplugged/tests/topics/loaders/test_curriculum_integrations_loader.py
+++ b/csunplugged/tests/topics/loaders/test_curriculum_integrations_loader.py
@@ -1,5 +1,4 @@
 import os.path
-from unittest.mock import Mock
 
 from tests.BaseTestWithDB import BaseTestWithDB
 from tests.topics.TopicsTestDataGenerator import TopicsTestDataGenerator

--- a/csunplugged/tests/topics/loaders/test_curriculum_integrations_loader.py
+++ b/csunplugged/tests/topics/loaders/test_curriculum_integrations_loader.py
@@ -12,7 +12,6 @@ class CurriculumIntegrationsLoaderTest(BaseTestWithDB):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_log = Mock()
         self.test_data = TopicsTestDataGenerator()
         self.loader_name = "curriculum_integrations"
 
@@ -22,7 +21,7 @@ class CurriculumIntegrationsLoaderTest(BaseTestWithDB):
         self.test_data.create_curriculum_area("1")
         topic = self.test_data.create_topic("1")
 
-        ci_loader = CurriculumIntegrationsLoader(self.load_log, config_file, topic, self.test_data.LOADER_ASSET_PATH)
+        ci_loader = CurriculumIntegrationsLoader(config_file, topic, self.test_data.LOADER_ASSET_PATH)
         ci_loader.load()
 
         ci_objects = CurriculumIntegration.objects.all()

--- a/csunplugged/tests/topics/loaders/test_lessons_loader.py
+++ b/csunplugged/tests/topics/loaders/test_lessons_loader.py
@@ -1,5 +1,4 @@
 import os.path
-from unittest.mock import Mock
 
 from tests.BaseTestWithDB import BaseTestWithDB
 from tests.topics.TopicsTestDataGenerator import TopicsTestDataGenerator

--- a/csunplugged/tests/topics/loaders/test_lessons_loader.py
+++ b/csunplugged/tests/topics/loaders/test_lessons_loader.py
@@ -16,7 +16,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_log = Mock()
         self.test_data = TopicsTestDataGenerator()
         self.loader_name = "lessons"
 
@@ -30,7 +29,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -53,7 +51,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -75,7 +72,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -96,7 +92,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -118,7 +113,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -139,7 +133,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -161,7 +154,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -182,7 +174,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -208,7 +199,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -234,7 +224,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -259,7 +248,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -281,7 +269,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -302,7 +289,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -324,7 +310,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -345,7 +330,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -372,7 +356,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -414,7 +397,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -436,7 +418,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -465,7 +446,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -489,7 +469,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -517,7 +496,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -539,7 +517,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,
@@ -561,7 +538,6 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_loader = LessonsLoader(
             config_file,
-            self.load_log,
             lessons_structure,
             topic,
             unit_plan,

--- a/csunplugged/tests/topics/loaders/test_programming_exercises_loader.py
+++ b/csunplugged/tests/topics/loaders/test_programming_exercises_loader.py
@@ -1,5 +1,4 @@
 import os.path
-from unittest.mock import Mock
 
 from tests.BaseTestWithDB import BaseTestWithDB
 from tests.topics.TopicsTestDataGenerator import TopicsTestDataGenerator

--- a/csunplugged/tests/topics/loaders/test_programming_exercises_loader.py
+++ b/csunplugged/tests/topics/loaders/test_programming_exercises_loader.py
@@ -12,7 +12,6 @@ class ProgrammingExercisesLoaderTest(BaseTestWithDB):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_log = Mock()
         self.test_data = TopicsTestDataGenerator()
         self.loader_name = "programming_exercises"
 
@@ -23,7 +22,7 @@ class ProgrammingExercisesLoaderTest(BaseTestWithDB):
         self.test_data.create_programming_language("1")
         topic = self.test_data.create_topic("1")
 
-        pe_loader = ProgrammingExercisesLoader(self.load_log, config_file, topic, self.test_data.LOADER_ASSET_PATH)
+        pe_loader = ProgrammingExercisesLoader(config_file, topic, self.test_data.LOADER_ASSET_PATH)
         pe_loader.load()
 
         pe_objects = ProgrammingExercise.objects.all()

--- a/csunplugged/tests/topics/loaders/test_unit_plan_loader.py
+++ b/csunplugged/tests/topics/loaders/test_unit_plan_loader.py
@@ -12,7 +12,6 @@ class UnitPlanLoaderTest(BaseTestWithDB):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.load_log = Mock()
         self.test_data = TopicsTestDataGenerator()
         self.loader_name = "unit_plan"
         self.BASE_PATH = os.path.join(self.test_data.LOADER_ASSET_PATH, self.loader_name)
@@ -22,7 +21,7 @@ class UnitPlanLoaderTest(BaseTestWithDB):
         factory = Mock()
         topic = self.test_data.create_topic('1')
 
-        up_loader = UnitPlanLoader(factory, self.load_log, config_file, topic, self.BASE_PATH)
+        up_loader = UnitPlanLoader(factory, config_file, topic, self.BASE_PATH)
         up_loader.load()
 
         up_objects = UnitPlan.objects.all()

--- a/csunplugged/topics/management/commands/_CurriculumAreasLoader.py
+++ b/csunplugged/topics/management/commands/_CurriculumAreasLoader.py
@@ -81,7 +81,7 @@ class CurriculumAreasLoader(BaseLoader):
             )
             new_area.save()
 
-            self.log("Added Curriculum Area: {}".format(new_area.__str__()))
+            self.log("Added curriculum area: {}".format(new_area.__str__()))
 
             # Create children curriculum areas with reference to parent
             if "children" in curriculum_area_data:
@@ -116,7 +116,6 @@ class CurriculumAreasLoader(BaseLoader):
                     )
                     new_child.save()
 
-                    self.log("Added Child Curriculum Area: {}".format(new_child.__str__()), 1)
+                    self.log("Added child curriculum area: {}".format(new_child.__str__()), 1)
 
-        # Print log output
-        self.print_load_log()
+        self.log("All curriculum areas loaded!\n")

--- a/csunplugged/topics/management/commands/_CurriculumIntegrationsLoader.py
+++ b/csunplugged/topics/management/commands/_CurriculumIntegrationsLoader.py
@@ -13,16 +13,15 @@ from topics.models import CurriculumArea, Lesson
 class CurriculumIntegrationsLoader(BaseLoader):
     """Custom loader for loading curriculum integrations."""
 
-    def __init__(self, load_log, structure_file_path, topic, BASE_PATH):
+    def __init__(self, structure_file_path, topic, BASE_PATH):
         """Create the loader for loading curriculum integrations.
 
         Args:
-            load_log: List of log messages (list).
             structure_file_path: File path for structure YAML file (string).
             topic: Object of related topic model.
             BASE_PATH: Base file path (string).
         """
-        super().__init__(BASE_PATH, load_log)
+        super().__init__(BASE_PATH)
         self.structure_file_path = os.path.join(self.BASE_PATH, structure_file_path)
         self.BASE_PATH = os.path.join(self.BASE_PATH, os.path.split(structure_file_path)[0])
         self.topic = topic
@@ -114,4 +113,4 @@ class CurriculumIntegrationsLoader(BaseLoader):
                                     "Lessons"
                                 )
 
-            self.log("Added Curriculum Integration: {}".format(integration.name), 1)
+            self.log("Added curriculum integration: {}".format(integration.name), 1)

--- a/csunplugged/topics/management/commands/_GlossaryTermsLoader.py
+++ b/csunplugged/topics/management/commands/_GlossaryTermsLoader.py
@@ -50,7 +50,6 @@ class GlossaryTermsLoader(BaseLoader):
                 glossary_term.term = glossary_term_content.title
                 glossary_term.definition = glossary_term_content.html_string
                 glossary_term.save()
-                self.log("Added Glossary Term: {}".format(glossary_term.__str__()))
+                self.log("Added glossary term: {}".format(glossary_term.__str__()))
 
-        # Print log output
-        self.print_load_log()
+        self.log("All glossary terms loaded!\n")

--- a/csunplugged/topics/management/commands/_LearningOutcomesLoader.py
+++ b/csunplugged/topics/management/commands/_LearningOutcomesLoader.py
@@ -72,7 +72,6 @@ class LearningOutcomesLoader(BaseLoader):
                         "Curriculum Areas"
                     )
 
-            self.log("Added Learning Outcome: {}".format(outcome.__str__()))
+            self.log("Added learning outcome: {}".format(outcome.__str__()))
 
-        # Print log output
-        self.print_load_log()
+        self.log("All learning outcomes loaded!\n")

--- a/csunplugged/topics/management/commands/_LessonsLoader.py
+++ b/csunplugged/topics/management/commands/_LessonsLoader.py
@@ -18,18 +18,17 @@ from topics.models import (
 class LessonsLoader(BaseLoader):
     """Custom loader for loading lessons."""
 
-    def __init__(self, unit_plan_structure_file_path, load_log, lessons_structure, topic, unit_plan, BASE_PATH):
+    def __init__(self, unit_plan_structure_file_path, lessons_structure, topic, unit_plan, BASE_PATH):
         """Create the loader for loading lessons.
 
         Args:
             unit_plan_structure_file_path: file path to unit plan yaml file (string).
-            load_log: List of log messages (list).
             lessons_structure: List of dictionaries for each lesson (list).
             topic: Object of Topic model.
             unit_plan: Object of UnitPlan model.
             BASE_PATH: Base file path (string).
         """
-        super().__init__(BASE_PATH, load_log)
+        super().__init__(BASE_PATH)
         self.unit_plan_structure_file_path = unit_plan_structure_file_path
         self.lessons_structure = lessons_structure
         self.topic = topic
@@ -192,4 +191,4 @@ class LessonsLoader(BaseLoader):
                         )
                         relationship.save()
 
-            self.log("Added Lesson: {}".format(lesson.__str__()), 2)
+            self.log("Added lesson: {}".format(lesson.__str__()), 2)

--- a/csunplugged/topics/management/commands/_ProgrammingExercisesLoader.py
+++ b/csunplugged/topics/management/commands/_ProgrammingExercisesLoader.py
@@ -18,16 +18,15 @@ from topics.models import (
 class ProgrammingExercisesLoader(BaseLoader):
     """Custom loader for loading programming challenges."""
 
-    def __init__(self, load_log, structure_file_path, topic, BASE_PATH):
+    def __init__(self, structure_file_path, topic, BASE_PATH):
         """Create the loader for loading programming challenges.
 
         Args:
-            load_log: List of log messages (list).
             structure_file_path: File path for structure YAML file (string).
             topic: Object of related topic model.
             BASE_PATH: Base file path (string).
         """
-        super().__init__(BASE_PATH, load_log)
+        super().__init__(BASE_PATH)
         self.structure_file_path = os.path.join(self.BASE_PATH, structure_file_path)
         self.BASE_PATH = os.path.join(self.BASE_PATH, os.path.split(structure_file_path)[0])
         self.topic = topic
@@ -110,7 +109,7 @@ class ProgrammingExercisesLoader(BaseLoader):
             )
             programming_challenge.save()
 
-            LOG_TEMPLATE = "Added Programming Challenge: {}"
+            LOG_TEMPLATE = "Added programming challenge: {}"
             self.log(LOG_TEMPLATE.format(programming_challenge.name), 1)
 
             for language in challenge_languages:
@@ -171,7 +170,7 @@ class ProgrammingExercisesLoader(BaseLoader):
                 )
                 implementation.save()
 
-                LOG_TEMPLATE = "Added Language Implementation: {}"
+                LOG_TEMPLATE = "Added language implementation: {}"
                 self.log(LOG_TEMPLATE.format(implementation.language), 2)
 
             if "learning-outcomes" in challenge_structure:

--- a/csunplugged/topics/management/commands/_ProgrammingExercisesStructureLoader.py
+++ b/csunplugged/topics/management/commands/_ProgrammingExercisesStructureLoader.py
@@ -82,7 +82,7 @@ class ProgrammingExercisesStructureLoader(BaseLoader):
 
             new_language.save()
 
-            self.log("Added Langauge: {}".format(new_language.__str__()))
+            self.log("Added programming langauge: {}".format(new_language.__str__()))
 
         for (difficulty, difficulty_data) in difficulty_levels.items():
 
@@ -107,7 +107,6 @@ class ProgrammingExercisesStructureLoader(BaseLoader):
             )
             new_difficulty.save()
 
-            self.log("Added Difficulty Level: {}".format(new_difficulty.__str__()))
+            self.log("Added programming difficulty level: {}".format(new_difficulty.__str__()))
 
-        # Print log output
-        self.print_load_log()
+        self.log("")

--- a/csunplugged/topics/management/commands/_TopicLoader.py
+++ b/csunplugged/topics/management/commands/_TopicLoader.py
@@ -99,7 +99,6 @@ class TopicLoader(BaseLoader):
             programming_challenges_structure_file_path = topic_structure["programming-challenges"]
             if programming_challenges_structure_file_path is not None:
                 self.factory.create_programming_exercises_loader(
-                    self.load_log,
                     programming_challenges_structure_file_path,
                     topic,
                     self.BASE_PATH
@@ -108,7 +107,6 @@ class TopicLoader(BaseLoader):
         # Load unit plans
         for unit_plan_file_path in unit_plans:
             self.factory.create_unit_plan_loader(
-                self.load_log,
                 unit_plan_file_path,
                 topic,
                 self.BASE_PATH
@@ -118,11 +116,9 @@ class TopicLoader(BaseLoader):
             curriculum_integrations_structure_file_path = topic_structure["curriculum-integrations"]
             if curriculum_integrations_structure_file_path is not None:
                 self.factory.create_curriculum_integrations_loader(
-                    self.load_log,
                     curriculum_integrations_structure_file_path,
                     topic,
                     self.BASE_PATH
                 ).load()
 
-        # Print log output
-        self.print_load_log()
+        self.log("")

--- a/csunplugged/topics/management/commands/_UnitPlanLoader.py
+++ b/csunplugged/topics/management/commands/_UnitPlanLoader.py
@@ -9,17 +9,16 @@ from utils.errors.MissingRequiredFieldError import MissingRequiredFieldError
 class UnitPlanLoader(BaseLoader):
     """Custom loader for loading unit plans."""
 
-    def __init__(self, factory, load_log, structure_file_path, topic, BASE_PATH):
+    def __init__(self, factory, structure_file_path, topic, BASE_PATH):
         """Create the loader for loading unit plans.
 
         Args:
             factory: LoaderFactory object for creating loaders (LoaderFactory).
-            load_log: List of log messages (list).
             structure_file_path: File path for structure YAML file (string).
             topic: Object of related topic model.
             BASE_PATH: Base file path (string).
         """
-        super().__init__(BASE_PATH, load_log)
+        super().__init__(BASE_PATH)
         self.factory = factory
         self.unit_plan_slug = os.path.split(structure_file_path)[0]
         self.structure_file_path = os.path.join(self.BASE_PATH, structure_file_path)
@@ -56,7 +55,7 @@ class UnitPlanLoader(BaseLoader):
         )
         unit_plan.save()
 
-        self.log("Added Unit Plan: {}".format(unit_plan.name), 1)
+        self.log("Added unit plan: {}".format(unit_plan.name), 1)
 
         # Load the lessons for the unit plan
 
@@ -72,7 +71,6 @@ class UnitPlanLoader(BaseLoader):
         lessons_structure = unit_plan_structure
         self.factory.create_lessons_loader(
             self.structure_file_path,
-            self.load_log,
             lessons_structure,
             self.topic,
             unit_plan,

--- a/csunplugged/utils/BaseLoader.py
+++ b/csunplugged/utils/BaseLoader.py
@@ -22,17 +22,12 @@ from utils.errors.CouldNotFindConfigFileError import CouldNotFindConfigFileError
 class BaseLoader():
     """Base loader class for individual loaders."""
 
-    def __init__(self, BASE_PATH="", load_log=[]):
+    def __init__(self, BASE_PATH=""):
         """Create a BaseLoader object.
 
         Args:
             BASE_PATH: string of base path (str).
-            load_log: list of log messages (list).
         """
-        if load_log:
-            self.load_log = load_log
-        else:
-            self.load_log = list(load_log)
         self.BASE_PATH = BASE_PATH
         self.setup_md_to_html_converter()
 
@@ -90,17 +85,16 @@ class BaseLoader():
         check_converter_glossary_links(result.required_glossary_terms, md_file_path)
         return result
 
-    def log(self, log_message, indent_amount=0):
-        """Add the log message to the load log with the specified indent."""
-        self.load_log.append((log_message, indent_amount))
+    def log(self, message, indent_amount=0):
+        """Output the log message to the load log.
 
-    def print_load_log(self):
-        """Output log messages from loader to console."""
-        for (log, indent_amount) in self.load_log:
-            indent = "  " * indent_amount
-            sys.stdout.write("{indent}{text}\n".format(indent=indent, text=log))
-        sys.stdout.write("\n")
-        self.load_log = []
+        Args:
+            message: Text to display (str).
+            indent_amount: Amount of indentation required (int).
+        """
+        indent = "  " * indent_amount
+        text = "{indent}{text}\n".format(indent=indent, text=message)
+        sys.stdout.write(text)
 
     def load_yaml_file(self, yaml_file_path):
         """Load and read given YAML file.

--- a/csunplugged/utils/LoaderFactory.py
+++ b/csunplugged/utils/LoaderFactory.py
@@ -19,9 +19,9 @@ class LoaderFactory:
         """Create curriculum area loader."""
         return CurriculumAreasLoader(structure_file_path, BASE_PATH)
 
-    def create_curriculum_integrations_loader(self, load_log, structure_file_path, topic, BASE_PATH):
+    def create_curriculum_integrations_loader(self, structure_file_path, topic, BASE_PATH):
         """Create curriculum integrations loader."""
-        return CurriculumIntegrationsLoader(load_log, structure_file_path, topic, BASE_PATH)
+        return CurriculumIntegrationsLoader(structure_file_path, topic, BASE_PATH)
 
     def create_glossary_terms_loader(self, glossary_folder_path, structure_file_path, BASE_PATH):
         """Create glossary terms loader."""
@@ -31,13 +31,13 @@ class LoaderFactory:
         """Create learning outcomes loader."""
         return LearningOutcomesLoader(structure_file_path, BASE_PATH)
 
-    def create_lessons_loader(self, structure_file_path, load_log, lessons_structure, topic, unit_plan, BASE_PATH):
+    def create_lessons_loader(self, structure_file_path, lessons_structure, topic, unit_plan, BASE_PATH):
         """Create lessons loader."""
-        return LessonsLoader(structure_file_path, load_log, lessons_structure, topic, unit_plan, BASE_PATH)
+        return LessonsLoader(structure_file_path, lessons_structure, topic, unit_plan, BASE_PATH)
 
-    def create_programming_exercises_loader(self, load_log, structure_file, topic, BASE_PATH):
+    def create_programming_exercises_loader(self, structure_file, topic, BASE_PATH):
         """Create programming exercises loader."""
-        return ProgrammingExercisesLoader(load_log, structure_file, topic, BASE_PATH)
+        return ProgrammingExercisesLoader(structure_file, topic, BASE_PATH)
 
     def create_programming_exercises_structure_loader(self, structure_file_path, BASE_PATH):
         """Create programming exercises structure loader."""
@@ -47,9 +47,9 @@ class LoaderFactory:
         """Create topic loader."""
         return TopicLoader(self, structure_file_path, BASE_PATH)
 
-    def create_unit_plan_loader(self, load_log, structure_file_path, topic, BASE_PATH):
+    def create_unit_plan_loader(self, structure_file_path, topic, BASE_PATH):
         """Create unit plan loader."""
-        return UnitPlanLoader(self, load_log, structure_file_path, topic, BASE_PATH)
+        return UnitPlanLoader(self, structure_file_path, topic, BASE_PATH)
 
     def create_resources_loader(self, structure_file, BASE_PATH):
         """Create resources loader."""


### PR DESCRIPTION
This allows for clearer process of the loading state of the system (especially as the content grows).