### PR TITLE
Updates to templates and lesson text

### DIFF
--- a/csunplugged/templates/topics/lesson.html
+++ b/csunplugged/templates/topics/lesson.html
@@ -27,8 +27,9 @@
 {% endblock page_heading %}
 
 {% block left_column_content %}
-  <h2 class="heading-underline">Learning Outcomes</h2>
+
   {% if learning_outcomes %}
+  <h2 class="heading-underline">Learning Outcomes</h2>
     <p>Students will be able to:</p>
     <ul>
       {% for learning_outcome in learning_outcomes %}
@@ -40,8 +41,6 @@
         </li>
       {% endfor %}
     </ul>
-  {% else %}
-    <p>No learning outcomes listed for {{ lesson.name }}.</p>
   {% endif %}
 
   {% render_html_field lesson.content %}
@@ -53,8 +52,8 @@
 {% endblock left_column_content %}
 
 {% block right_column_content %}
-  <h2 class="heading-underline">CS Unplugged resources</h2>
   {% if generated_resources %}
+  <h2 class="heading-underline">CS Unplugged resources</h2>
     <div class="link-box-container">
       {% for generated_resource in generated_resources %}
         <a href="{% url 'resources:resource' generated_resource.slug %}" class="link-box">
@@ -64,30 +63,24 @@
         </a>
       {% endfor %}
     </div>
-  {% else %}
-    <p>No CS Unplugged resources required.</p>
   {% endif %}
 
-  <h2 class="heading-underline mt-2">Classroom resources</h2>
   {% if lesson.classroom_resources %}
+  <h2 class="heading-underline mt-2">Classroom resources</h2>
     <ul>
       {% for classroom_resource in lesson.classroom_resources %}
         <li>{{ classroom_resource }}</li>
       {% endfor %}
     </ul>
-  {% else %}
-    <p>No classroom resources required.</p>
   {% endif %}
 
-  <h2 class="heading-underline mt-2">Programming challenges</h2>
   {% if programming_challenges %}
+  <h2 class="heading-underline mt-2">Programming challenges</h2>
     <p>
       <a href="{% url 'topics:programming_challenges_list' topic.slug unit_plan.slug lesson.slug %}">
         View related programming challenges
       </a>
     </p>
-  {% else %}
-    <p>No programming challenges for {{ lesson.name }}</p>
   {% endif %}
 
   <div id="sticky-sidebar" class="sticky">

--- a/csunplugged/templates/topics/topic.html
+++ b/csunplugged/templates/topics/topic.html
@@ -33,15 +33,13 @@
     {% endif %}
   {% endfor %}
 
-  <h2 id="integrations" class="heading-underline">Curriculum Integrations</h2>
   {% if curriculum_integrations %}
+  <h2 id="integrations" class="heading-underline">Curriculum Integrations</h2>
     {% include "topics/curriculum-integrations-table.html" %}
-  {% else %}
-    <p>No curriculum integrations for {{ topic }}.</p>
   {% endif %}
 
-  <h2 id="resources" class="heading-underline">Resources</h2>
   {% if resources %}
+  <h2 id="resources" class="heading-underline">Resources</h2>
     <p>
       The following resources are used in {{ topic.name }} lessons, and can
       be accessed here (and also on each lesson page).
@@ -54,8 +52,6 @@
         </a>
       {% endfor %}
     </div>
-  {% else %}
-    <p>No resources are related to {{ topic }}.</p>
   {% endif %}
 
   {% if topic.other_resources %}

--- a/csunplugged/topics/content/en/error-detection-and-correction/unit-plan/lessons/parity-magic.md
+++ b/csunplugged/topics/content/en/error-detection-and-correction/unit-plan/lessons/parity-magic.md
@@ -46,14 +46,14 @@ from the Computer Science Field Guide.
 
 ### Potential answers could include:
 
+Students may come up with situations where computers won't read a disc or scan a code, but they may also confuse this kind of problem with other kinds of failures such as an error in a program or a flat battery.
+
 {image file-path="img/topics/school-test-error.png" alt="A school test shows every question marked correct but the overall score is 0%."}
 
-We use computers for important things like banking, writing school reports, and
-communicating with each other.
-If the information being stored got changed without anyone knowing, you'd get
-the wrong balance in your account (too much or too little), the wrong grade in
-your report, or the wrong message in an email.
-This activity will look at how to correct this automatically.
+Adults use computers for important things like banking, writing school reports, and communicating with each other.
+If the information being stored got changed without anyone knowing, you'd get the wrong balance in your account (too much or too little), the wrong grade in your report, or the wrong message in an email.
+Or worst still the website you are wanting to go to for your learning or the DVD you want to play won’t work!
+This activity will look at how computers correct this automatically.
 
 ## Lesson Starter
 

--- a/csunplugged/topics/content/en/learning-outcomes.yaml
+++ b/csunplugged/topics/content/en/learning-outcomes.yaml
@@ -99,7 +99,7 @@ error-explain-each-card-bit:
     - algorithmic-thinking
 
 error-explain-chose-parity-card:
-  text: Explain why they chose each extra card when setting up the parity column/row.
+  text: Explain why they chose each extra bit (card) when setting up a parity column/row.
   curriculum-areas:
     - generalising-and-patterns
 


### PR DESCRIPTION
Fixes #460 - hides sections from template when there is no content to display (e.g. if there are no resources for a lesson, then there should not a resources section).

Also updated text for a LO #462 and text in a lesson #447 