### PR TITLE
Add csu command to reboot django container after exception occurs.

### DIFF
--- a/csu
+++ b/csu
@@ -182,6 +182,13 @@ dev_shell() {
 }
 defhelp -dev shell "Open shell to Django folder."
 
+# Reboot Django Docker container
+dev_reboot_django() {
+  echo "Rebooting Django Docker container..."
+  docker-compose up -d django
+}
+defhelp -dev reboot_django 'Reboot Django Docker container.'
+
 # Run style checks
 dev_style() {
   echo "Running PEP8 style checker..."


### PR DESCRIPTION
The django docker conatiner shuts down when a change is made to a core django file (eg. models.py) that results in an exception. This PR adds a dev command (reboot_django) to the csu helper script to reboot the django server.