### PR TITLE
Update npm packages

### DIFF
--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -1,28 +1,28 @@
 {
   "name": "cs-unplugged-assets",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "main": "gulpfile.js",
   "private": true,
   "dependencies": {
-    "autoprefixer": "6.7.6",
+    "autoprefixer": "7.1.6",
     "child_process": "1.0.2",
-    "del": "2.2.2",
+    "del": "3.0.0",
     "gulp": "3.9.1",
     "gulp-if": "2.0.2",
     "gulp-jshint": "2.0.4",
     "gulp-notify": "3.0.0",
-    "gulp-postcss": "6.3.0",
+    "gulp-postcss": "7.0.0",
     "gulp-rename": "1.2.2",
     "gulp-sass": "3.1.0",
-    "gulp-sourcemaps": "2.4.1",
+    "gulp-sourcemaps": "2.6.1",
     "gulp-util": "3.0.8",
-    "jshint": "2.9.4",
+    "jshint": "2.9.5",
     "jshint-stylish": "2.2.1",
-    "postcss-flexbugs-fixes": "2.1.0",
-    "run-sequence": "1.2.2",
+    "postcss-flexbugs-fixes": "3.2.0",
+    "run-sequence": "2.2.0",
     "scratchblocks": "3.1.2",
     "through2": "2.0.3",
     "vinyl-buffer": "1.0.0",
-    "yargs": "6.6.0"
+    "yargs": "10.0.3"
   }
 }


### PR DESCRIPTION
This updates the npm packages used to generate static files to (hopefully) fix npm errors in TravisCI of corrupted versions. Regardless, the packages can be updated.