### PR TITLE
Lower copy amount for resources with copies

### DIFF
--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -209,6 +209,7 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
-# ENVIRONMENT VARIABLES
+# OTHER SETTINGS
 # ------------------------------------------------------------------------------
 DJANGO_PRODUCTION = env.bool("DJANGO_PRODUCTION")
+RESOURCE_COPY_AMOUNT = 20

--- a/csunplugged/resources/management/commands/makeresources.py
+++ b/csunplugged/resources/management/commands/makeresources.py
@@ -6,6 +6,7 @@ from urllib.parse import urlencode
 from tqdm import tqdm
 from django.core.management.base import BaseCommand
 from django.http.request import QueryDict
+from django.conf import settings
 from resources.models import Resource
 from resources.views.views import generate_resource_pdf
 from resources.utils.get_resource_generator import get_resource_generator
@@ -50,7 +51,7 @@ class Command(BaseCommand):
             # Create PDF for all possible combinations
             for combination in progress_bar:
                 if resource.copies:
-                    combination["copies"] = 30
+                    combination["copies"] = settings.RESOURCE_COPY_AMOUNT
                 requested_options = QueryDict(urlencode(combination, doseq=True))
                 generator = get_resource_generator(resource.generator_module, requested_options)
                 (pdf_file, filename) = generate_resource_pdf(resource.name, generator)

--- a/csunplugged/resources/views/views.py
+++ b/csunplugged/resources/views/views.py
@@ -48,6 +48,7 @@ def resource(request, resource_slug):
     context["debug"] = settings.DEBUG
     context["resource_thumbnail_base"] = "{}img/resources/{}/thumbnails/".format(settings.STATIC_URL, resource.slug)
     context["grouped_lessons"] = group_lessons_by_age(resource.lessons.all())
+    context["copies_amount"] = settings.RESOURCE_COPY_AMOUNT
     if resource.thumbnail_static_path:
         context["thumbnail"] = resource.thumbnail_static_path
     return render(request, resource.webpage_template, context)

--- a/csunplugged/templates/resources/resource.html
+++ b/csunplugged/templates/resources/resource.html
@@ -56,7 +56,7 @@
     {% else %}
       {% if resource.copies %}
       <div class="alert alert-info" role="alert">
-        The download of this resource includes 30 unique copies.
+        The download of this resource includes {{ copies_amount }} unique copies.
       </div>
       {% endif %}
 

--- a/csunplugged/tests/resources/management/test_makeresources_command.py
+++ b/csunplugged/tests/resources/management/test_makeresources_command.py
@@ -69,4 +69,4 @@ class MakeResourcesCommandTest(BaseTestWithDB):
         management.call_command("makeresources")
         filepath = self.RESOURCE_PATH.format("Resource Grid (a4).pdf")
         pdf = PdfFileReader(open(filepath, "rb"))
-        self.assertEqual(pdf.getNumPages(), 30)
+        self.assertEqual(pdf.getNumPages(), 20)


### PR DESCRIPTION
To fix #650 (generation of Treasure Hunt exceeding Travis CI job limit), either one (or more) of the following needed to occur:

- **Lower combinations of resource** - A removal of any one option would dramatically reduce the time to create this resource. however every option is either critical or useful for this resource.
- **Reducing the copies produced** - Currently 30 copies of each combination is produced, this number can be reduced.
- **Improve processing logic or optimise resource files** - This option would require a lot of tweaking and testing for possible little gains. It appears the number of combinations and then creating 30 copies for each combination takes the most time.

I chose to take the second option, as it doesn't minimise the effectiveness of the activity by reducing options of the resource. This does serve as a reminder to deploy the render service.