### PR TITLE
Collect resource thumbnails for static file deployment 

### DIFF
--- a/infrastructure/dev-deploy/deploy-static-files.sh
+++ b/infrastructure/dev-deploy/deploy-static-files.sh
@@ -5,7 +5,11 @@
 ./csu start
 
 # Generate production static files
+rm -r build/
+rm -r staticfiles/
 ./csu dev static_prod
+./csu dev static_scratch
+./csu dev makeresourcethumbnails
 ./csu dev collect_static
 
 # Install Google Cloud SDK

--- a/infrastructure/prod-deploy/deploy-static-files.sh
+++ b/infrastructure/prod-deploy/deploy-static-files.sh
@@ -5,7 +5,11 @@
 ./csu start
 
 # Generate production static files
+rm -r build/
+rm -r staticfiles/
 ./csu dev static_prod
+./csu dev static_scratch
+./csu dev makeresourcethumbnails
 ./csu dev collect_static
 
 # Install Google Cloud SDK


### PR DESCRIPTION
Resource thumbnail images were not collected for deployment, therefore the scripts have been updated to  include the resource thumbnails. I also added clearer steps by deleting existing folders and creating production static files from a fresh slate, as Scratch image files were being deployed but accidentally as a remnant from the start up script.

Fixes #653 