### PR TITLE
Add language picker if more than one language is available

### DIFF
--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -121,7 +121,7 @@ LANGUAGES = (
 if env.bool("INCLUDE_INCONTEXT_L10N", False):
     EXTRA_LANGUAGES = [
         (INCONTEXT_L10N_PSEUDOLANGUAGE, "Translation mode"),
-        (INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI, "In-Translation mode (Bi-directional)"),
+        (INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI, "Translation mode (Bi-directional)"),
     ]
 
     EXTRA_LANG_INFO = {

--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -15,6 +15,7 @@ import os.path
 # Add custom languages not provided by Django
 import django.conf.locale
 from django.conf import global_settings
+from django.utils.translation import ugettext_lazy as _
 
 # cs-unplugged/csunplugged/config/settings/base.py - 3 = csunplugged/
 ROOT_DIR = environ.Path(__file__) - 3
@@ -119,22 +120,22 @@ LANGUAGES = (
 
 if env.bool("INCLUDE_INCONTEXT_L10N", False):
     EXTRA_LANGUAGES = [
-        (INCONTEXT_L10N_PSEUDOLANGUAGE, "In-context translations"),
-        (INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI, "In-context translations (Bidi)"),
+        (INCONTEXT_L10N_PSEUDOLANGUAGE, "Translation mode"),
+        (INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI, "In-Translation mode (Bi-directional)"),
     ]
 
     EXTRA_LANG_INFO = {
         INCONTEXT_L10N_PSEUDOLANGUAGE: {
             'bidi': False,
             'code': INCONTEXT_L10N_PSEUDOLANGUAGE,
-            'name': "In-context translations",
-            'name_local': "In-context translations",
+            'name': "Translation mode",
+            'name_local': _("Translation mode"),
         },
         INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI: {
             'bidi': True,
             'code': INCONTEXT_L10N_PSEUDOLANGUAGE_BIDI,
-            'name': "In-context translations (Bidi)",
-            'name_local': "In-context translations (Bidi)",
+            'name': "Translation mode (Bi-directional)",
+            'name_local': _("Translation mode (Bi-directional)"),
         }
     }
 

--- a/csunplugged/templates/base.html
+++ b/csunplugged/templates/base.html
@@ -54,6 +54,19 @@
             <a class="nav-item nav-link" href="{% url 'resources:index' %}">{% trans "Resources" %}</a>
             <a class="nav-item nav-link" href="{% url 'general:about' %}">{% trans "About" %}</a>
           </div>
+          {% if LANGUAGES|length > 1 %}
+            <div class="navbar-nav">
+              <div class="nav-item dropdown">
+                <a class="nav-link dropdown-toggle" href="#" id="navbarLanguageSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ current_language.name_local|capfirst }}</a>
+                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="navbarLanguageSelector">
+                  {% for language in LANGUAGES %}
+                    {% get_language_info for language.0 as lang %}
+                    <a class="dropdown-item" href="{% translate_url language.0 %}">{{ lang.name_local|capfirst }}</a>
+                  {% endfor %}
+                </div>
+              </div>
+            </div>
+          {% endif %}
         </div>
       </div>
     </nav>


### PR DESCRIPTION
This adds a language picker if more than one language is available, useful for when in-context languages are available on the development website.

If the list of languages becomes too long, we can display the translation languages at the end of the list.