### PR TITLE
Issue/716 take two

### DIFF
--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/de/translation-difficulties.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/de/translation-difficulties.yaml
@@ -1,2 +1,2 @@
-1:
+difficulty-1:
   name: German difficulty 1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/basic-config-difficulties.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/basic-config-difficulties.yaml
@@ -1,2 +1,2 @@
-1:
+difficulty-1:
   name: Level 1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/empty-difficulties-name-difficulties.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/empty-difficulties-name-difficulties.yaml
@@ -1,2 +1,2 @@
-1:
+difficulty-1:
   name:

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/translation-difficulties.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/en/translation-difficulties.yaml
@@ -1,4 +1,4 @@
-1:
+difficulty-1:
   name: English difficulty 1
-2:
+difficulty-2:
   name: English difficulty 2

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/basic-config.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/basic-config.yaml
@@ -3,4 +3,4 @@ languages:
     number: 1
 
 difficulties:
-  - 1
+  - difficulty-1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-difficulties-name.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-difficulties-name.yaml
@@ -3,4 +3,4 @@ languages:
     number: 1
 
 difficulties:
-  - 1
+  - difficulty-1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-languages-data.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-languages-data.yaml
@@ -2,4 +2,4 @@ languages:
   language-1:
 
 difficulties:
-  - 1
+  - difficulty-1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-languages-number.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/empty-languages-number.yaml
@@ -3,4 +3,4 @@ languages:
     number:
 
 difficulties:
-  - 1
+  - difficulty-1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/missing-languages.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/missing-languages.yaml
@@ -1,2 +1,2 @@
 difficulties:
-  1:
+  - difficulty-1

--- a/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/translation.yaml
+++ b/csunplugged/tests/topics/loaders/assets/programming_challenges_structure/structure/translation.yaml
@@ -5,5 +5,5 @@ languages:
     number: 2
 
 difficulties:
-  - 1
-  - 2
+  - difficulty-1
+  - difficulty-2

--- a/csunplugged/tests/topics/loaders/test_programming_challenges_structure_loader.py
+++ b/csunplugged/tests/topics/loaders/test_programming_challenges_structure_loader.py
@@ -108,7 +108,7 @@ class ProgrammingChallengesStructureLoaderTest(BaseTestWithDB):
         with translation.override("de"):
             self.assertEqual("German language 1", translated_lang.name)
 
-        translated_difficulty = ProgrammingChallengeDifficulty.objects.get(level=1)
+        translated_difficulty = ProgrammingChallengeDifficulty.objects.get(level=0)
         self.assertSetEqual(set(["en", "de"]), set(translated_difficulty.languages))
         self.assertEqual("English difficulty 1", translated_difficulty.name)
         with translation.override("de"):
@@ -127,7 +127,7 @@ class ProgrammingChallengesStructureLoaderTest(BaseTestWithDB):
         with translation.override("de"):
             self.assertEqual("English language 2", untranslated_lang.name)
 
-        untranslated_difficulty = ProgrammingChallengeDifficulty.objects.get(level=2)
+        untranslated_difficulty = ProgrammingChallengeDifficulty.objects.get(level=1)
         self.assertSetEqual(set(["en"]), set(untranslated_difficulty.languages))
         self.assertEqual("English difficulty 2", untranslated_difficulty.name)
         # Check name does not fall back to english for missing translation

--- a/csunplugged/topics/content/en/programming-challenges-structure-difficulties.yaml
+++ b/csunplugged/topics/content/en/programming-challenges-structure-difficulties.yaml
@@ -1,8 +1,8 @@
-"0":
+difficulty-0:
   name: Try it out
-"1":
+difficulty-1:
   name: Beginner
-"2":
+difficulty-2:
   name: Growing experience
-"3":
+difficulty-3:
   name: Ready to expand

--- a/csunplugged/topics/content/structure/programming-challenges-structure.yaml
+++ b/csunplugged/topics/content/structure/programming-challenges-structure.yaml
@@ -9,7 +9,7 @@ languages:
         icon: img/python-logo.png
 
 difficulties:
-  - "0"
-  - "1"
-  - "2"
-  - "3"
+  - difficulty-0
+  - difficulty-1
+  - difficulty-2
+  - difficulty-3

--- a/csunplugged/topics/management/commands/_ProgrammingChallengesStructureLoader.py
+++ b/csunplugged/topics/management/commands/_ProgrammingChallengesStructureLoader.py
@@ -86,13 +86,13 @@ class ProgrammingChallengesStructureLoader(TranslatableModelLoader):
             required_fields=["name"],
         )
 
-        for difficulty in difficulty_levels:
+        for level, difficulty_slug in enumerate(difficulty_levels):
 
             new_difficulty = ProgrammingChallengeDifficulty(
-                level=int(difficulty),
+                level=level,
             )
 
-            translations = difficulties_translations.get(difficulty, dict())
+            translations = difficulties_translations.get(difficulty_slug, dict())
             self.populate_translations(new_difficulty, translations)
             self.mark_translation_availability(new_difficulty, required_fields=["name"])
             new_difficulty.save()

--- a/infrastructure/crowdin/crowdin_bot_scripts/crowdin-bot-pull-incontext.sh
+++ b/infrastructure/crowdin/crowdin_bot_scripts/crowdin-bot-pull-incontext.sh
@@ -40,7 +40,11 @@ crowdin -c "${CROWDIN_CONFIG_FILE}" -l "${CROWDIN_PSEUDO_LANGUAGE}" download
 python3 -m crowdin_bot.download_xliff
 python3 -m crowdin_bot.modify_pseudo_translations
 
-git add "csunplugged/topics/content/${CSU_PSEUDO_LANGUAGE}"
+
+for content_path in "${CONTENT_PATHS[@]}"; do
+  git add "${content_path}/${CSU_PSEUDO_LANGUAGE}"
+done
+
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
 if [[ $(git diff --cached) ]]; then


### PR DESCRIPTION
A second attempt to fix #716...

This uses keys `difficulty-0`, `difficulty-1` etc for the different difficulty models. The actual level (integer) is taken as it's index in the list of difficulties in `programming-challenges-structure.yaml`.

A minor bugfix in crowdin-bot-pull-incontext.sh is also included in this PR.