### PR TITLE
Lock Django version to 1.11 LTS (fixes #743)

### DIFF
--- a/infrastructure/crowdin/requirements.txt
+++ b/infrastructure/crowdin/requirements.txt
@@ -1,4 +1,4 @@
 verto==0.6.1
 PyYAML==3.12
-django==1.11.7
+django==1.11.7 # pyup: >=1.11,<2.0
 django-environ==0.4.4


### PR DESCRIPTION
Locks Django to LTS version for PyUP.