### PR TITLE
Remove duplicate learning outcomes (fixes #827)

### DIFF
--- a/csunplugged/tests/topics/views/test_lesson_view.py
+++ b/csunplugged/tests/topics/views/test_lesson_view.py
@@ -285,6 +285,34 @@ class LessonViewTest(BaseTestWithDB):
             ordered=False
         )
 
+    # Created to avoid https://github.com/uccser/cs-unplugged/issues/827
+    def test_lesson_view_ages_context_learning_outcome_not_duplicated(self):
+        topic = self.test_data.create_topic(1)
+        unit_plan = self.test_data.create_unit_plan(topic, 1)
+        age_group_1 = self.test_data.create_age_group(5, 7)
+        lesson = self.test_data.create_lesson(
+            topic,
+            unit_plan,
+            1,
+            age_group_1
+        )
+        learning_outcome = self.test_data.create_learning_outcome(1)
+        area_1 = self.test_data.create_curriculum_area(1)
+        area_2 = self.test_data.create_curriculum_area(2)
+        learning_outcome.curriculum_areas.add(area_1, area_2)
+        lesson.learning_outcomes.add(learning_outcome)
+        kwargs = {
+            "topic_slug": "topic-1",
+            "unit_plan_slug": "unit-plan-1",
+            "lesson_slug": "lesson-1",
+        }
+        url = reverse("topics:lesson", kwargs=kwargs)
+        response = self.client.get(url)
+        self.assertQuerysetEqual(
+            response.context["learning_outcomes"],
+            ["<LearningOutcome: Outcome 1>"]
+        )
+
     def test_lesson_view_ages_context_learning_outcome_none(self):
         topic = self.test_data.create_topic(1)
         unit_plan = self.test_data.create_unit_plan(topic, 1)

--- a/csunplugged/tests/topics/views/test_programming_challenge_view.py
+++ b/csunplugged/tests/topics/views/test_programming_challenge_view.py
@@ -173,6 +173,27 @@ class ProgrammingChallengeViewTest(BaseTestWithDB):
             ]
         )
 
+    # Created to avoid https://github.com/uccser/cs-unplugged/issues/827
+    def test_programming_challenge_view_ages_context_learning_outcome_not_duplicated(self):
+        topic = self.test_data.create_topic(1)
+        difficulty = self.test_data.create_difficulty_level(1)
+        challenge = self.test_data.create_programming_challenge(topic, 1, difficulty)
+        learning_outcome = self.test_data.create_learning_outcome(1)
+        area_1 = self.test_data.create_curriculum_area(1)
+        area_2 = self.test_data.create_curriculum_area(2)
+        learning_outcome.curriculum_areas.add(area_1, area_2)
+        challenge.learning_outcomes.add(learning_outcome)
+        kwargs = {
+            "topic_slug": topic.slug,
+            "programming_challenge_slug": challenge.slug,
+        }
+        url = reverse("topics:programming_challenge", kwargs=kwargs)
+        response = self.client.get(url)
+        self.assertQuerysetEqual(
+            response.context["learning_outcomes"],
+            ["<LearningOutcome: Outcome 1>"]
+        )
+
     def test_programming_challenge_view_implementations_context(self):
         topic = self.test_data.create_topic(1)
         difficulty = self.test_data.create_difficulty_level(1)

--- a/csunplugged/topics/views.py
+++ b/csunplugged/topics/views.py
@@ -187,7 +187,7 @@ class LessonView(generic.DetailView):
         context["programming_challenges"] = self.object.programming_challenges.exists()
         # Add all the connected learning outcomes
         context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects").order_by("text")
-        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects").order_by("text")
+        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects").order_by("description")
         # Add all the connected generated resources
         related_resources = self.object.generated_resources.order_by("name")
         generated_resources = []

--- a/csunplugged/topics/views.py
+++ b/csunplugged/topics/views.py
@@ -186,10 +186,8 @@ class LessonView(generic.DetailView):
         # Add all the connected programming challenges
         context["programming_challenges"] = self.object.programming_challenges.exists()
         # Add all the connected learning outcomes
-        context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects") \
-                                           .all().select_related()
-        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects") \
-                                             .all().select_related()
+        context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects").order_by("text")
+        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects").order_by("text")
         # Add all the connected generated resources
         related_resources = self.object.generated_resources.order_by("name")
         generated_resources = []

--- a/csunplugged/topics/views.py
+++ b/csunplugged/topics/views.py
@@ -187,7 +187,9 @@ class LessonView(generic.DetailView):
         context["programming_challenges"] = self.object.programming_challenges.exists()
         # Add all the connected learning outcomes
         context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects").order_by("text")
-        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects").order_by("description")
+        context["classroom_resources"] = self.object.classroom_resources(manager="translated_objects").order_by(
+            "description"
+        )
         # Add all the connected generated resources
         related_resources = self.object.generated_resources.order_by("name")
         generated_resources = []
@@ -266,7 +268,7 @@ class ProgrammingChallengeView(generic.DetailView):
             lesson.challenge_number = challenge_numbers.challenge_number
         context["topic"] = self.object.topic
         # Add all the connected learning outcomes
-        context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects").all()
+        context["learning_outcomes"] = self.object.learning_outcomes(manager="translated_objects").order_by("text")
         context["implementations"] = self.object.ordered_implementations()
         return context
 


### PR DESCRIPTION
Due to joining three tables together across many to many relationships, learning outcomes were being duplicated on lesson page.

Can't believe we didn't spot this sooner, especially how we complained the learning outcome lists were so long!

Fixes #827 