### PR TITLE
Display language picker at top level of navbar on mobile device

### DIFF
--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -530,19 +530,6 @@ ol, ul {
 h1, h2, h3, h4, h5, h6, details {
   clear: both;
 }
-.icon {
-  display: block;
-  margin: auto;
-  width: 1em;
-  height: 1em;
-  stroke-width: 0;
-  stroke: $white;
-  fill: $white;
-}
-button:hover .icon {
-  stroke: $red;
-  fill: $red;
-}
 
 @media print {
   body {
@@ -638,12 +625,45 @@ button:hover .icon {
 }
 
 #navbarLanguageSelector {
-   @extend .navbar-toggler;
-   display: block !important;
+  padding: 4px 7.25px;
+  font-size: 1.25rem;
+  line-height: 1;
+  background-color: transparent;
+  border: 1px solid $white;
+  border-radius: 0.25rem;
+  cursor: pointer;
+}
+@include media-breakpoint-up("md") {
+  #navbarLanguageSelector {
+    border-color: transparent;
+  }
+  #navbarLanguageSelector:hover,
+  #navbarLanguageSelector:focus {
+    border-color: $white;
+  }
 }
 #navbarLanguageDropdown.dropdown-menu-right {
   right: 0;
   left: auto;
+}
+
+.icon {
+  display: block;
+  margin: auto;
+  stroke-width: 0;
+  stroke: $white;
+  fill: $white;
+}
+.icon-language {
+  height: 1.5em;
+}
+.icon-search {
+  width: 1em;
+  height: 1em;
+}
+button:hover .icon-search {
+  stroke: $red;
+  fill: $red;
 }
 
 #search-navbar {

--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -637,16 +637,13 @@ button:hover .icon {
   }
 }
 
-// This removes the navbar button from the document flow,
-// allowing the logo to display perfectly center.
-.navbar > .container {
-  position: relative;
-  justify-content: center;
-  > .navbar-toggler {
-    position: absolute;
-    top: 0;
-    left: 0;
-  }
+#navbarLanguageSelector {
+   @extend .navbar-toggler;
+   display: block !important;
+}
+#navbarLanguageDropdown.dropdown-menu-right {
+  right: 0;
+  left: auto;
 }
 
 #search-navbar {

--- a/csunplugged/templates/base.html
+++ b/csunplugged/templates/base.html
@@ -247,6 +247,19 @@
       </div>
 
       <div class="container py-3 footer-statement text-center">
+        <p class="mb-0">
+          <small>
+            {% for language in LANGUAGES %}
+              {% get_language_info for language.0 as lang %}
+              <a href="{% translate_url language.0 %}">
+                {{ lang.name_local|capfirst }}
+              </a>{% if not forloop.last %} | {% endif %}
+            {% endfor %}
+          </small>
+        </p>
+      </div>
+
+      <div class="container py-3 footer-statement text-center">
         <p>
           <small>
             {% blocktrans trimmed %}

--- a/csunplugged/templates/base.html
+++ b/csunplugged/templates/base.html
@@ -53,6 +53,26 @@
         <a class="navbar-brand mr-0" href="{% url 'general:home' %}">
           <img src="{% static 'img/logo-mono-small.svg' %}" id="navbar-brand-logo" class="d-inline-block align-top" alt="CS Unplugged logo">
         </a>
+        <div class="dropdown ml-3 order-md-last">
+          <button type="button" id="navbarLanguageSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            <!-- SVG from https://thenounproject.com/term/translation/987/ (Public Domain) -->
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 100 75.446" xml:space="preserve" class="icon">
+              <title>{% trans "Language" %}</title>
+              <g>
+                <path d="M19.198,44.002v-8.201h-8.575c-3.319,0-6.021-2.874-6.021-6.406V10.903c0-3.533,2.701-6.408,6.021-6.408h38.345   c3.319,0,6.019,2.875,6.019,6.408v18.492c0,3.532-2.7,6.406-6.019,6.406v4.496c5.797,0,10.514-4.891,10.514-10.902V10.903   C59.482,4.892,54.766,0,48.968,0H10.623C4.824,0,0.107,4.892,0.107,10.903v18.492c0,6.011,4.717,10.902,10.516,10.902h4.08v7.968   c0,1.223,0.789,2.332,1.963,2.764c0.334,0.123,0.677,0.184,1.014,0.184c0.821,0,1.609-0.354,2.165-1.01l8.369-9.905h8.353v-4.496   H26.128L19.198,44.002z"></path>
+                <path d="M89.377,24.233h-25.96v4.496h25.96c3.319,0,6.021,2.875,6.021,6.408v18.489c0,3.533-2.701,6.408-6.021,6.408h-8.574v8.205   l-6.931-8.203H51.031c-3.318,0-6.019-2.875-6.019-6.408V35.137c0-3.533,2.701-6.408,6.019-6.408v-4.496   c-5.797,0-10.515,4.892-10.515,10.903v18.491c0,6.014,4.717,10.904,10.515,10.904h20.754l8.372,9.91   c0.555,0.652,1.342,1.004,2.161,1.004c0.337,0,0.68-0.059,1.014-0.182c1.176-0.432,1.967-1.543,1.967-2.768V64.53h4.078   c5.799,0,10.516-4.891,10.516-10.904V35.137C99.893,29.125,95.176,24.233,89.377,24.233z"></path>
+                <path d="M26.532,7.437l-7.952,20.951h4.665l1.644-4.665h7.834l1.584,4.665h4.782L31.255,7.437H26.532z M26.093,20.29l2.729-7.688   h0.058l2.641,7.688H26.093z"></path>
+                <path d="M60.12,49.114c0,2.297,1.468,3.787,3.862,3.787c2.876-0.061,5.721-1.887,6.647-2.711c0.926-0.826,3.42-3.693,4.521-5.963   c1.393,0.658,2.053,1.76,2.053,2.98c0,2.639-2.542,4.17-6.599,4.635l1.968,2.725c6.354-0.832,8.516-3.5,8.516-7.408   c0-3.301-2.077-5.305-4.74-6.183c0.049-0.242,0.138-0.495,0.188-0.74l-3.611-0.643c-0.024,0.365-0.097,0.432-0.168,0.798   c-1.297-0.074-2.738,0.121-3.202,0.219c0-0.66,0.024-2.421,0.049-3.055c3.006-0.122,5.962-0.365,8.699-0.781l-0.318-3.566   c-2.81,0.562-5.523,0.856-8.186,1.003c0.072-0.71,0.172-2.717,0.172-2.717l-3.813-0.291c-0.05,0.978-0.072,2.127-0.121,3.128   c-1.688,0.024-3.689,0.024-4.742,0l0.171,3.446h0.414c1.003,0,2.641-0.051,4.109-0.099c0,0.952,0.023,3.005,0.048,3.934   C62.589,43.051,60.12,45.717,60.12,49.114z M71.606,43.59c-0.514,1.025-1.124,1.957-1.808,2.736   c-0.1-0.807-0.148-1.637-0.196-2.516C69.87,43.762,70.945,43.59,71.606,43.59z M66.229,45.008c0.123,1.369,0.27,2.688,0.489,3.885   c-0.634,0.318-1.244,0.514-1.809,0.539c-1.223,0.049-1.223-0.732-1.223-1.076C63.687,47.059,64.689,45.864,66.229,45.008z"></path>
+              </g>
+            </svg>
+          </button>
+          <div id="navbarLanguageDropdown" class="dropdown-menu dropdown-menu-{{ LANGUAGE_END }}" aria-labelledby="navbarLanguageSelector">
+            {% for language in LANGUAGES %}
+              {% get_language_info for language.0 as lang %}
+              <a class="dropdown-item{% if LANGUAGE_CODE == lang.code %} active{% endif %}" href="{% translate_url language.0 %}">{{ lang.name_local|capfirst }}</a>
+            {% endfor %}
+          </div>
+        </div>
         <div class="collapse navbar-collapse" id="navbarNav">
           <div class="navbar-nav navbar-nav-i18n mr-auto">
             <a class="nav-item nav-link" href="{% url 'topics:index' %}">{% trans "Topics" %}</a>
@@ -68,26 +88,13 @@
                   <button class="btn btn-outline-light btn-sm" type="submit">
                     <!-- SVG from Icomoon-Free -->
                     <svg version="1.1" xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32" class="icon icon-search">
-                      <title>Search</title>
+                      <title>{% trans "Search" %}</title>
                       <path d="M31.008 27.231l-7.58-6.447c-0.784-0.705-1.622-1.029-2.299-0.998 1.789-2.096 2.87-4.815 2.87-7.787 0-6.627-5.373-12-12-12s-12 5.373-12 12 5.373 12 12 12c2.972 0 5.691-1.081 7.787-2.87-0.031 0.677 0.293 1.515 0.998 2.299l6.447 7.58c1.104 1.226 2.907 1.33 4.007 0.23s0.997-2.903-0.23-4.007zM12 20c-4.418 0-8-3.582-8-8s3.582-8 8-8 8 3.582 8 8-3.582 8-8 8z"></path>
                     </svg>
                   </button>
                 </div>
               </div>
             </form>
-          {% endif %}
-          {% if LANGUAGES|length > 1 %}
-            <div class="navbar-nav">
-              <div class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="navbarLanguageSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">{{ current_language.name_local|capfirst }}</a>
-                <div class="dropdown-menu dropdown-menu-{{ LANGUAGE_END }}" aria-labelledby="navbarLanguageSelector">
-                  {% for language in LANGUAGES %}
-                    {% get_language_info for language.0 as lang %}
-                    <a class="dropdown-item" href="{% translate_url language.0 %}">{{ lang.name_local|capfirst }}</a>
-                  {% endfor %}
-                </div>
-              </div>
-            </div>
           {% endif %}
         </div>
       </div>

--- a/csunplugged/templates/base.html
+++ b/csunplugged/templates/base.html
@@ -53,10 +53,10 @@
         <a class="navbar-brand mr-0" href="{% url 'general:home' %}">
           <img src="{% static 'img/logo-mono-small.svg' %}" id="navbar-brand-logo" class="d-inline-block align-top" alt="CS Unplugged logo">
         </a>
-        <div class="dropdown ml-3 order-md-last">
+        <div class="dropdown ml-md-3 order-md-last">
           <button type="button" id="navbarLanguageSelector" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <!-- SVG from https://thenounproject.com/term/translation/987/ (Public Domain) -->
-            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 100 75.446" xml:space="preserve" class="icon">
+            <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" viewBox="0 0 100 75.446" xml:space="preserve" class="icon icon-language">
               <title>{% trans "Language" %}</title>
               <g>
                 <path d="M19.198,44.002v-8.201h-8.575c-3.319,0-6.021-2.874-6.021-6.406V10.903c0-3.533,2.701-6.408,6.021-6.408h38.345   c3.319,0,6.019,2.875,6.019,6.408v18.492c0,3.532-2.7,6.406-6.019,6.406v4.496c5.797,0,10.514-4.891,10.514-10.902V10.903   C59.482,4.892,54.766,0,48.968,0H10.623C4.824,0,0.107,4.892,0.107,10.903v18.492c0,6.011,4.717,10.902,10.516,10.902h4.08v7.968   c0,1.223,0.789,2.332,1.963,2.764c0.334,0.123,0.677,0.184,1.014,0.184c0.821,0,1.609-0.354,2.165-1.01l8.369-9.905h8.353v-4.496   H26.128L19.198,44.002z"></path>


### PR DESCRIPTION
The language picker now also uses a universal symbol to changing language, will need user testing to see if this works effectively.

Also adds available language options to footer.

Fixes #998 