### PR TITLE
Remove 'odd-parroty-parity' image as word play doesn't work across languages

### DIFF
--- a/csunplugged/topics/content/en/error-detection-and-correction/unit-plan/unit-plan.md
+++ b/csunplugged/topics/content/en/error-detection-and-correction/unit-plan/unit-plan.md
@@ -89,8 +89,6 @@ error it tries to put the data back to how it should have been.
 **Error control** is the general term for error correction and error detection
 systems.
 
-{image file-path="img/topics/odd-parroty-parity.png"}
-
 “**Parity**” often comes up in error control as there is a well-known method
 based on it.
 The word "parity" has a general meaning of simply saying if a number is even or

--- a/csunplugged/topics/content/xx_LR/error-detection-and-correction/unit-plan/unit-plan.md
+++ b/csunplugged/topics/content/xx_LR/error-detection-and-correction/unit-plan/unit-plan.md
@@ -64,8 +64,6 @@ crwdns20255:0crwdne20255:0
 
 *BlockTag: crwdns20256:0crwdne20256:0*
 
-{image file-path="img/topics/odd-parroty-parity.png"}
-
 crwdns20257:0crwdne20257:0 crwdns20258:0crwdne20258:0 crwdns20259:0crwdne20259:0 crwdns20260:0crwdne20260:0 crwdns20261:0crwdne20261:0
 
 crwdns20262:0crwdne20262:0 crwdns20263:0crwdne20263:0


### PR DESCRIPTION
File remains in repository for the moment. Fixes #404.