### PR TITLE
Add not available badge if prerequisite lesson has no translation available.

### DIFF
--- a/csunplugged/templates/topics/curriculum-integration.html
+++ b/csunplugged/templates/topics/curriculum-integration.html
@@ -54,10 +54,11 @@
                 <strong>{{ lesson.unit_plan.name }}:</strong> {{ lesson.name }}
                 ({% for age_group in lesson.age_group.all %}{{ age_group.ages.lower }} to {{ age_group.ages.upper }}{% if not forloop.last %} and {% endif %}{% endfor %})
               </a>
+              {% if not lesson.translation_available %}
+                <br>
+                {% include "generic/not-available-badge.html" %}
+              {% endif %}
             </li>
-            {% if not lesson.translation_available %}
-              {% include "generic/not-available-badge.html" %}
-            {% endif %}
             {% endfor %}
         </ul>
       </div>

--- a/csunplugged/templates/topics/curriculum-integration.html
+++ b/csunplugged/templates/topics/curriculum-integration.html
@@ -55,6 +55,9 @@
                 ({% for age_group in lesson.age_group.all %}{{ age_group.ages.lower }} to {{ age_group.ages.upper }}{% if not forloop.last %} and {% endif %}{% endfor %})
               </a>
             </li>
+            {% if not lesson.translation_available %}
+              {% include "generic/not-available-badge.html" %}
+            {% endif %}
             {% endfor %}
         </ul>
       </div>


### PR DESCRIPTION
This PR adds the not-available-badge to prerequisite lessons if the lesson has no translation available in the current language. Resolves #1037 

![image](https://user-images.githubusercontent.com/16066822/45128150-8192de00-b1d0-11e8-828f-311cef05ea16.png)

