### PR TITLE
Provide clearer translation strings for pages unavailable in a specific language

### DIFF
--- a/csunplugged/classic/models.py
+++ b/csunplugged/classic/models.py
@@ -1,10 +1,13 @@
 """Models for the classic application."""
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 
 
 class ClassicPage(models.Model):
     """Model for Classic CS Unplugged page in database."""
+
+    MODEL_NAME = _("Classic CS Unplugged page")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(unique=True)
@@ -18,14 +21,6 @@ class ClassicPage(models.Model):
             URL as string.
         """
         return self.redirect
-
-    def model_type(self):
-        """Text name of ClassicPage model.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Classic CS Unplugged page"
 
     def __str__(self):
         """Text representation of ClassicPage object.

--- a/csunplugged/general/models.py
+++ b/csunplugged/general/models.py
@@ -2,10 +2,13 @@
 
 from django.db import models
 from django.urls import reverse
+from django.utils.translation import ugettext_lazy as _
 
 
 class GeneralPage(models.Model):
     """Model for general page in database."""
+
+    MODEL_NAME = _("General page")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(unique=True)
@@ -20,14 +23,6 @@ class GeneralPage(models.Model):
             URL as string.
         """
         return reverse(self.url_name)
-
-    def model_type(self):
-        """Text name of GeneralPage model.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "General page"
 
     def __str__(self):
         """Text representation of GeneralPage object.

--- a/csunplugged/resources/models.py
+++ b/csunplugged/resources/models.py
@@ -1,12 +1,15 @@
 """Models for the resources application."""
 
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 from django.urls import reverse
 from utils.TranslatableModel import TranslatableModel
 
 
 class Resource(TranslatableModel):
     """Model for resource in database."""
+
+    MODEL_NAME = _("Printable")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(unique=True)
@@ -26,14 +29,6 @@ class Resource(TranslatableModel):
             "resource_slug": self.slug
         }
         return reverse("resources:resource", kwargs=kwargs)
-
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Resource"
 
     def __str__(self):
         """Text representation of Resource object.

--- a/csunplugged/templates/404.html
+++ b/csunplugged/templates/404.html
@@ -16,7 +16,7 @@
         <ul>
           <li>
             <a href="{% url 'general:home' %}">
-              {% trans "Home page" %}
+              {% trans "Homepage" %}
             </a>
           </li>
           {% if LANGUAGE_CODE == "en" %}

--- a/csunplugged/templates/search/search.html
+++ b/csunplugged/templates/search/search.html
@@ -88,7 +88,7 @@
                 <div class="row">
                   {% with object=result.object %}
                     <div class="col-12 col-sm-3 text-sm-right">
-                      {{ object.model_type }}
+                      {{ object.MODEL_NAME }}
                     </div>
                     <div class="col-12 col-sm-9">
                       {% with template="search/result/"|add:result.model_name|add:".html" %}

--- a/csunplugged/templates/topics/curriculum-integration.html
+++ b/csunplugged/templates/topics/curriculum-integration.html
@@ -26,10 +26,7 @@
     </p>
   {% endif %}
   {% if not integration.translation_available %}
-    {% url "topics:topic" topic.slug as parent_url %}
-    {% trans "topic" as topic_l10n %}
-    {% trans "curriculum integration" as curriculum_integration_l10n %}
-    {% with model=integration model_type=curriculum_integration_l10n parent=topic parent_type=topic_l10n parent_url=parent_url %}
+    {% with model=integration parent=topic %}
       {% include "topics/not-available-warning.html" %}
     {% endwith %}
   {% endif %}

--- a/csunplugged/templates/topics/lesson.html
+++ b/csunplugged/templates/topics/lesson.html
@@ -19,10 +19,7 @@
 {% block page_heading %}
     <h1 id="{{ lesson.slug }}">{{ lesson.name }}</h1>
     {% if not lesson.translation_available %}
-      {% url "topics:unit_plan" topic.slug unit_plan.slug as parent_url %}
-      {% trans "unit plan" as unit_plan_l10n %}
-      {% trans "lesson" as lesson_l10n %}
-      {% with model=lesson model_type=lesson_l10n parent=unit_plan parent_type=unit_plan_l10n parent_url=parent_url %}
+      {% with model=lesson parent=unit_plan %}
         {% include "topics/not-available-warning.html" %}
       {% endwith %}
     {% else %}

--- a/csunplugged/templates/topics/not-available-warning.html
+++ b/csunplugged/templates/topics/not-available-warning.html
@@ -7,22 +7,26 @@
   <h4>Sorry! This item is not yet available in {{ language }}.</h4>
   <p>This item is available in the following languages:</p>
   {% endblocktrans %}
-  <p>
-    <div class="btn-group">
-      {% for language in model.languages %}
-        {% get_language_info for language as lang %}
-        <a class="btn btn-outline-danger" role="button" href="{% translate_url language %}">
+  <ul>
+    {% for language in model.languages %}
+      {% get_language_info for language as lang %}
+      <li>
+        <a href="{% translate_url language %}">
           {{ lang.name_local }}
         </a>
-      {% endfor %}
-    </div>
-  </p>
-  {% if parent_type %}
-    <p>...{% trans "or" %}...</p>
-    <a class="btn btn-outline-danger" role="button" href="{{ parent_url }}">
-      {% blocktrans trimmed %}
-      Return to the {{ parent_type }}
-      {% endblocktrans %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% if parent %}
+    <p>
+      <a class="btn btn-outline-danger" href="{{ parent.get_absolute_url }}">
+        {{ model.RETURN_TO_PARENT }}
+      </a>
+    </p>
+  {% endif %}
+  <p>
+    <a class="btn btn-outline-danger" href="{% url 'general:home' %}">
+      {% trans "Return to homepage "%}
     </a>
-    {% endif %}
+  </p>
 </div>

--- a/csunplugged/templates/topics/programming-challenge-language-solution.html
+++ b/csunplugged/templates/topics/programming-challenge-language-solution.html
@@ -27,10 +27,7 @@
     {{ implementation.language.name }} {% trans "solution" %}
   </h2>
   {% if not implementation.translation_available %}
-    {% url "topics:programming_challenge" topic.slug programming_challenge.slug as parent_url %}
-    {% trans "solution" as solution_l10n %}
-    {% trans "challenge" as challenge_l10n %}
-    {% with model=implementation model_type=solution_l10n parent=programming_challenge parent_type=challenge_l10n parent_url=parent_url %}
+    {% with model=implementation parent=programming_challenge %}
       {% include 'topics/not-available-warning.html' %}
     {% endwith %}
   {% endif %}

--- a/csunplugged/templates/topics/programming-challenge.html
+++ b/csunplugged/templates/topics/programming-challenge.html
@@ -20,10 +20,7 @@
     {{ programming_challenge.name }}
   </h1>
   {% if not programming_challenge.translation_available %}
-    {% trans "programming challenge" as programming_challenge_l10n %}
-    {% url "topics:topic" topic.slug as parent_url %}
-    {% trans "topic" as topic_l10n %}
-    {% with model=programming_challenge model_type=programming_challenge_l10n parent=topic parent_type=topic_l10n parent_url=parent_url %}
+    {% with model=programming_challenge parent=topic %}
       {% include 'topics/not-available-warning.html' %}
     {% endwith %}
   {% else %}

--- a/csunplugged/templates/topics/topic.html
+++ b/csunplugged/templates/topics/topic.html
@@ -17,10 +17,7 @@
 {% block page_heading %}
   <h1 id="{{ topic.slug }}">{{ topic.name }}</h1>
   {% if not topic.translation_available %}
-    {% trans "topic" as topic_l10n %}
-    {% trans "list of topics" as list_of_topics_l10n %}
-    {% url "topics:index" as parent_url %}
-    {% with model=topic model_type=topic_l10n parent_type=list_of_topics_l10n parent_url=parent_url %}
+    {% with model=topic %}
       {% include 'topics/not-available-warning.html' %}
     {% endwith %}
   {% endif %}

--- a/csunplugged/templates/topics/unit-plan-description.html
+++ b/csunplugged/templates/topics/unit-plan-description.html
@@ -18,10 +18,7 @@
 {% block page_heading %}
   <h1 id="{{ unit_plan.slug }}"><span class="text-muted">{% trans "Unit plan:" %}</span> {{ unit_plan.name }}</h1>
   {% if not topic.translation_available %}
-    {% url "topics:topic" topic.slug as parent_url %}
-    {% trans "unit plan" as unit_plan_l10n %}
-    {% trans "topic" as topic_l10n %}
-    {% with model=unit_plan model_type=unit_plan_l10n parent=topic parent_type=topic_l10n parent_url=parent_url %}
+    {% with model=unit_plan parent=topic %}
       {% include 'topics/not-available-warning.html' %}
     {% endwith %}
   {% endif %}

--- a/csunplugged/templates/topics/unit-plan.html
+++ b/csunplugged/templates/topics/unit-plan.html
@@ -17,10 +17,7 @@
 {% block page_heading %}
   <h1 id="{{ unit_plan.slug }}" class="mb-3"><span class="text-muted">{% trans "Unit plan:" %}</span> {{ unit_plan.name }}</h1>
   {% if not topic.translation_available %}
-    {% url "topics:topic" topic.slug as parent_url %}
-    {% trans "unit plan" as unit_plan_l10n %}
-    {% trans "topic" as topic_l10n %}
-    {% with model=unit_plan model_type=unit_plan_l10n parent=topic parent_type=topic_l10n parent_url=parent_url %}
+    {% with model=unit_plan parent=topic %}
       {% include 'topics/not-available-warning.html' %}
     {% endwith %}
   {% endif %}

--- a/csunplugged/tests/classic/models/test_classic_page.py
+++ b/csunplugged/tests/classic/models/test_classic_page.py
@@ -15,13 +15,13 @@ class ClassicPageModelTest(BaseTestWithDB):
         )
         self.assertEqual(page.__str__(), "Page")
 
-    def test_classic_page_model_type(self):
+    def test_classic_page_model_name(self):
         page = ClassicPage(
             slug="page",
             name="Page",
             redirect="http://www.example.com",
         )
-        self.assertEqual(page.model_type(), "Classic CS Unplugged page")
+        self.assertEqual(page.MODEL_NAME, "Classic CS Unplugged page")
 
     def test_classic_page_model_get_absolute_url(self):
         page = ClassicPage(

--- a/csunplugged/tests/general/models/test_general_page.py
+++ b/csunplugged/tests/general/models/test_general_page.py
@@ -17,14 +17,14 @@ class GeneralPageModelTest(BaseTestWithDB):
         )
         self.assertEqual(page.__str__(), "Page")
 
-    def test_general_page_model_type(self):
+    def test_general_page_model_name(self):
         page = GeneralPage(
             slug="page",
             name="Page",
             template="template.html",
             url_name="url",
         )
-        self.assertEqual(page.model_type(), "General page")
+        self.assertEqual(page.MODEL_NAME, "General page")
 
     @override_settings(ROOT_URLCONF="tests.general.models.assets.urls")
     def test_general_page_model_get_absolute_url(self):

--- a/csunplugged/tests/resources/models/test_resource.py
+++ b/csunplugged/tests/resources/models/test_resource.py
@@ -17,14 +17,14 @@ class ResourceModelTest(BaseTestWithDB):
         )
         self.assertEqual(resource.__str__(), "Grid")
 
-    def test_resource_model_type(self):
+    def test_resource_model_name(self):
         resource = self.test_data.create_resource(
             "grid",
             "Grid",
             "resources/grid.html",
             "GridResourceGenerator",
         )
-        self.assertEqual(resource.model_type(), "Resource")
+        self.assertEqual(resource.MODEL_NAME, "Printable")
 
     def test_resource_model_get_absolute_url(self):
         resource = self.test_data.create_resource(

--- a/csunplugged/tests/topics/models/test_curriculum_area.py
+++ b/csunplugged/tests/topics/models/test_curriculum_area.py
@@ -23,9 +23,9 @@ class CurriculumAreaModelTest(BaseTestWithDB):
             "Area 1: Area 2"
         )
 
-    def test_curriculum_area_model_type(self):
+    def test_curriculum_area_model_name(self):
         area = self.test_data.create_curriculum_area(1)
         self.assertEqual(
-            area.model_type(),
+            area.MODEL_NAME,
             "Curriculum Area"
         )

--- a/csunplugged/tests/topics/models/test_curriculum_integration.py
+++ b/csunplugged/tests/topics/models/test_curriculum_integration.py
@@ -13,10 +13,10 @@ class CurriculumIntegrationModelTest(BaseTestWithDB):
         curriculum_integration = self.test_data.create_integration(topic, 1)
         self.assertEqual(curriculum_integration.__str__(), "Integration 1")
 
-    def test_curriculum_integration_model_type(self):
+    def test_curriculum_integration_model_name(self):
         topic = self.test_data.create_topic(1)
         curriculum_integration = self.test_data.create_integration(topic, 1)
-        self.assertEqual(curriculum_integration.model_type(), "Curriculum Integration")
+        self.assertEqual(curriculum_integration.MODEL_NAME, "Curriculum Integration")
 
     def test_curriculum_integration_model_get_absolute_url(self):
         topic = self.test_data.create_topic(1)

--- a/csunplugged/tests/topics/models/test_lesson.py
+++ b/csunplugged/tests/topics/models/test_lesson.py
@@ -20,7 +20,7 @@ class LessonModelTest(BaseTestWithDB):
         )
         self.assertEqual(lesson.__str__(), "Lesson 1 (5 to 7)")
 
-    def test_lesson_model_type(self):
+    def test_lesson_model_name(self):
         topic = self.test_data.create_topic(1)
         unit_plan = self.test_data.create_unit_plan(topic, 1)
         age_group_1 = self.test_data.create_age_group(5, 7)
@@ -30,7 +30,7 @@ class LessonModelTest(BaseTestWithDB):
             1,
             age_group_1
         )
-        self.assertEqual(lesson.model_type(), "Lesson")
+        self.assertEqual(lesson.MODEL_NAME, "Lesson")
 
     def test_lesson_model_get_absolute_url(self):
         topic = self.test_data.create_topic(1)

--- a/csunplugged/tests/topics/models/test_programming_challenge.py
+++ b/csunplugged/tests/topics/models/test_programming_challenge.py
@@ -20,7 +20,7 @@ class ProgrammingChallengeModelTest(BaseTestWithDB):
         )
         self.assertEqual(challenge.__str__(), "Challenge 1.1: 1")
 
-    def test_programming_challenge_model_type(self):
+    def test_programming_challenge_model_name(self):
         topic = self.test_data.create_topic(1)
         difficulty = self.test_data.create_difficulty_level(1)
         language = self.test_data.create_programming_language(1)
@@ -30,7 +30,7 @@ class ProgrammingChallengeModelTest(BaseTestWithDB):
             language,
             challenge,
         )
-        self.assertEqual(challenge.model_type(), "Programming Challenge")
+        self.assertEqual(challenge.MODEL_NAME, "Programming Challenge")
 
     def test_programming_challenge_model_get_absolute_url(self):
         topic = self.test_data.create_topic(1)

--- a/csunplugged/tests/topics/models/test_topic.py
+++ b/csunplugged/tests/topics/models/test_topic.py
@@ -12,9 +12,9 @@ class TopicModelTest(BaseTestWithDB):
         topic = self.test_data.create_topic(1)
         self.assertEqual(topic.__str__(), "Topic 1")
 
-    def test_topic_model_type(self):
+    def test_topic_model_name(self):
         topic = self.test_data.create_topic(1)
-        self.assertEqual(topic.model_type(), "Topic")
+        self.assertEqual(topic.MODEL_NAME, "Topic")
 
     def test_topic_model_get_absolute_url(self):
         topic = self.test_data.create_topic(1)

--- a/csunplugged/tests/topics/models/test_unit_plan.py
+++ b/csunplugged/tests/topics/models/test_unit_plan.py
@@ -13,10 +13,10 @@ class UnitPlanModelTest(BaseTestWithDB):
         unit_plan = self.test_data.create_unit_plan(topic, 1)
         self.assertEqual(unit_plan.__str__(), "Unit Plan 1")
 
-    def test_unit_plan_model_type(self):
+    def test_unit_plan_model_name(self):
         topic = self.test_data.create_topic(1)
         unit_plan = self.test_data.create_unit_plan(topic, 1)
-        self.assertEqual(unit_plan.model_type(), "Unit Plan")
+        self.assertEqual(unit_plan.MODEL_NAME, "Unit Plan")
 
     def test_unit_plan_model_get_absolute_url(self):
         topic = self.test_data.create_topic(1)

--- a/csunplugged/topics/models.py
+++ b/csunplugged/topics/models.py
@@ -2,6 +2,7 @@
 
 from django.urls import reverse
 from django.db import models
+from django.utils.translation import ugettext_lazy as _
 from django.contrib.postgres.fields import JSONField, IntegerRangeField
 from resources.models import Resource
 from utils.TranslatableModel import TranslatableModel
@@ -27,6 +28,8 @@ class GlossaryTerm(TranslatableModel):
 class CurriculumArea(TranslatableModel):
     """Model for curriculum area in database."""
 
+    MODEL_NAME = _("Curriculum Area")
+
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(unique=True)
     name = models.CharField(max_length=100, default="")
@@ -37,14 +40,6 @@ class CurriculumArea(TranslatableModel):
         null=True,
         related_name="children"
     )
-
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Curriculum Area"
 
     def __str__(self):
         """Text representation of CurriculumArea object.
@@ -65,6 +60,8 @@ class CurriculumArea(TranslatableModel):
 
 class LearningOutcome(TranslatableModel):
     """Model for learning outcome in database."""
+
+    MODEL_NAME = _("Learning Outcome")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(max_length=80, unique=True)
@@ -91,6 +88,8 @@ class LearningOutcome(TranslatableModel):
 class ClassroomResource(TranslatableModel):
     """Model for classroom resource."""
 
+    MODEL_NAME = _("Classroom Resource")
+
     slug = models.SlugField(max_length=80, unique=True)
     description = models.CharField(max_length=100, default="")
 
@@ -105,6 +104,8 @@ class ClassroomResource(TranslatableModel):
 
 class Topic(TranslatableModel):
     """Model for topic in database."""
+
+    MODEL_NAME = _("Topic")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     slug = models.SlugField(unique=True)
@@ -124,14 +125,6 @@ class Topic(TranslatableModel):
         }
         return reverse("topics:topic", kwargs=kwargs)
 
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Topic"
-
     def __str__(self):
         """Text representation of Topic object.
 
@@ -143,6 +136,9 @@ class Topic(TranslatableModel):
 
 class UnitPlan(TranslatableModel):
     """Model for unit plan in database."""
+
+    MODEL_NAME = _("Unit Plan")
+    RETURN_TO_PARENT = _("Return to topic")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     topic = models.ForeignKey(
@@ -167,14 +163,6 @@ class UnitPlan(TranslatableModel):
             "unit_plan_slug": self.slug
         }
         return reverse("topics:unit_plan", kwargs=kwargs)
-
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Unit Plan"
 
     def __str__(self):
         """Text representation of UnitPlan object.
@@ -203,6 +191,9 @@ class ProgrammingChallengeDifficulty(TranslatableModel):
 
 class ProgrammingChallenge(TranslatableModel):
     """Model for programming challenge in database."""
+
+    MODEL_NAME = _("Programming Challenge")
+    RETURN_TO_PARENT = _("Return to topic")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     topic = models.ForeignKey(
@@ -237,14 +228,6 @@ class ProgrammingChallenge(TranslatableModel):
             "programming_challenge_slug": self.slug
         }
         return reverse("topics:programming_challenge", kwargs=kwargs)
-
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Programming Challenge"
 
     def ordered_implementations(self):
         """Return an ordered QuerySet of implementations.
@@ -343,6 +326,9 @@ class AgeGroup(TranslatableModel):
 class Lesson(TranslatableModel):
     """Model for lesson in database."""
 
+    MODEL_NAME = _("Lesson")
+    RETURN_TO_PARENT = _("Return to unit plan")
+
     #  Auto-incrementing 'id' field is automatically set by Django
     topic = models.ForeignKey(
         Topic,
@@ -426,14 +412,6 @@ class Lesson(TranslatableModel):
         }
         return reverse("topics:lesson", kwargs=kwargs)
 
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Lesson"
-
     def __str__(self):
         """Text representation of Lesson object.
 
@@ -469,6 +447,9 @@ class ProgrammingChallengeNumber(models.Model):
 
 class CurriculumIntegration(TranslatableModel):
     """Model for curriculum integration in database."""
+
+    MODEL_NAME = _("Curriculum Integration")
+    RETURN_TO_PARENT = _("Return to topic")
 
     #  Auto-incrementing 'id' field is automatically set by Django
     topic = models.ForeignKey(
@@ -509,14 +490,6 @@ class CurriculumIntegration(TranslatableModel):
             "integration_slug": self.slug
         }
         return reverse("topics:integration", kwargs=kwargs)
-
-    def model_type(self):
-        """Text name of model type.
-
-        Returns:
-            Name of the model (str).
-        """
-        return "Curriculum Integration"
 
     def __str__(self):
         """Text representation of CurriculumIntegration object.


### PR DESCRIPTION
Text is now not translated separately, but rather as one string.

Fixes #1038 