### PR TITLE
Add 'update_lite' command for faster local development

### DIFF
--- a/csu
+++ b/csu
@@ -111,6 +111,22 @@ cmd_update() {
 }
 defhelp update 'Run Django migrate and updatedata commands and build static files.'
 
+# Run update command only for key content
+dev_update_lite() {
+  dev_static
+  echo ""
+  dev_migrate
+  echo ""
+  echo "Loading content..."
+  docker-compose exec django /docker_venv/bin/python3 ./manage.py updatedata --lite-load
+  dev_collect_static
+  echo ""
+  echo -e "\n${GREEN}Key content is loaded!${NC}"
+  echo "Run the 'update' command to load all content"
+  echo "Open your preferred web browser to the URL 'localhost'"
+}
+defhelp -dev update_lite 'Run update command only for key content - Useful for development.'
+
 # Collecting static files
 dev_collect_static() {
   echo

--- a/csunplugged/general/management/commands/updatedata.py
+++ b/csunplugged/general/management/commands/updatedata.py
@@ -8,10 +8,20 @@ class Command(management.base.BaseCommand):
 
     help = "Update all data from content folders for all applications"
 
+    def add_arguments(self, parser):
+        """Add optional parameter to updatedata command."""
+        parser.add_argument(
+            "--lite-load",
+            action="store_true",
+            dest="lite_load",
+            help="Perform lite load (only load key content)",
+        )
+
     def handle(self, *args, **options):
         """Automatically called when the updatedata command is given."""
+        lite_load = options.get("lite_load")
         management.call_command("flush", interactive=False)
-        management.call_command("loadresources")
-        management.call_command("loadtopics")
-        management.call_command("loadgeneralpages")
-        management.call_command("loadclassicpages")
+        management.call_command("loadresources", lite_load=lite_load)
+        management.call_command("loadtopics", lite_load=lite_load)
+        management.call_command("loadgeneralpages", lite_load=lite_load)
+        management.call_command("loadclassicpages", lite_load=lite_load)

--- a/csunplugged/tests/general/management/test_updatedata_command.py
+++ b/csunplugged/tests/general/management/test_updatedata_command.py
@@ -14,3 +14,6 @@ class ManagementCommandTest(BaseTestWithDB):
 
     def test_updatedata_command(self):
         management.call_command("updatedata")
+
+    def test_updatedata_command_lite_load(self):
+        management.call_command("updatedata", lite_loader=True)

--- a/csunplugged/tests/utils/assets/lite-loader/text.md
+++ b/csunplugged/tests/utils/assets/lite-loader/text.md
@@ -1,0 +1,7 @@
+# Title
+
+Paragraph text.
+
+{image file-path="img/example.png"}
+
+Paragraph text with {glossary-link term="term"}glossary definition{glossary-link end}.

--- a/csunplugged/tests/utils/test_BaseLoader.py
+++ b/csunplugged/tests/utils/test_BaseLoader.py
@@ -1,9 +1,9 @@
 """Test class for BaseLoader class."""
 
+import os.path
 from django.test import SimpleTestCase
 from tests.utils.BareBaseLoader import BareBaseLoader
 from utils.errors.InvalidYAMLFileError import InvalidYAMLFileError
-import os.path
 
 TEST_ASSET_PATH = "tests/utils/assets/"
 
@@ -66,3 +66,10 @@ class BaseLoaderTest(SimpleTestCase):
                 loader.load_template_files(),
                 dict()
             )
+
+    def test_lite_loader(self):
+        test_file = os.path.join(TEST_ASSET_PATH, "lite-loader", "text.md")
+        loader = BareBaseLoader(
+            lite_loader=True,
+        )
+        loader.convert_md_file(test_file, "config.yaml")

--- a/csunplugged/topics/management/commands/_LessonsLoader.py
+++ b/csunplugged/topics/management/commands/_LessonsLoader.py
@@ -98,7 +98,7 @@ class LessonsLoader(TranslatableModelLoader):
             lesson.save()
 
             # Add programming challenges
-            if "programming-challenges" in lesson_structure:
+            if "programming-challenges" in lesson_structure and not self.lite_loader:
                 programming_challenge_slugs = lesson_structure["programming-challenges"]
                 if programming_challenge_slugs is not None:
                     # Check all slugs are valid

--- a/csunplugged/topics/management/commands/_TopicLoader.py
+++ b/csunplugged/topics/management/commands/_TopicLoader.py
@@ -77,7 +77,7 @@ class TopicLoader(TranslatableModelLoader):
         self.log("Added Topic: {}".format(topic.name))
 
         # Load programming challenges
-        if "programming-challenges" in topic_structure:
+        if "programming-challenges" in topic_structure and not self.lite_loader:
             programming_challenges_structure_file_path = topic_structure["programming-challenges"]
             if programming_challenges_structure_file_path is not None:
                 programming_challenges_path, structure_filename = os.path.split(
@@ -97,7 +97,8 @@ class TopicLoader(TranslatableModelLoader):
                 topic,
                 base_path=self.base_path,
                 content_path=os.path.join(self.content_path, content_path),
-                structure_filename=structure_filename
+                structure_filename=structure_filename,
+                lite_loader=self.lite_loader,
             ).load()
 
         if "curriculum-integrations" in topic_structure:

--- a/csunplugged/topics/management/commands/_UnitPlanLoader.py
+++ b/csunplugged/topics/management/commands/_UnitPlanLoader.py
@@ -92,7 +92,7 @@ class UnitPlanLoader(TranslatableModelLoader):
             content_path=os.path.join(self.content_path, lesson_path),
             structure_filename=lesson_structure_file,
             base_path=self.base_path,
-
+            lite_loader=self.lite_loader,
         ).load()
 
         # Create AgeGroup and assign to lessons

--- a/csunplugged/topics/management/commands/loadtopics.py
+++ b/csunplugged/topics/management/commands/loadtopics.py
@@ -13,6 +13,15 @@ class Command(BaseCommand):
 
     help = "Converts Markdown files listed in structure file and stores"
 
+    def add_arguments(self, parser):
+        """Add optional parameter to loadtopics command."""
+        parser.add_argument(
+            "--lite-load",
+            action="store_true",
+            dest="lite_load",
+            help="Perform lite load (only load key topics content)",
+        )
+
     def handle(self, *args, **options):
         """Automatically called when the loadresources command is given.
 
@@ -21,6 +30,7 @@ class Command(BaseCommand):
                 attribute.
         """
         factory = LoaderFactory()
+        lite_load = options.get("lite_load")
 
         # Get structure and content files
         base_loader = BaseLoader()
@@ -114,5 +124,6 @@ class Command(BaseCommand):
                 factory.create_topic_loader(
                     base_path=base_path,
                     content_path=topic_path,
-                    structure_filename=topic_structure_file
+                    structure_filename=topic_structure_file,
+                    lite_loader=lite_load,
                 ).load()

--- a/csunplugged/utils/BaseLoader.py
+++ b/csunplugged/utils/BaseLoader.py
@@ -25,19 +25,22 @@ from utils.errors.CouldNotFindYAMLFileError import CouldNotFindYAMLFileError
 class BaseLoader():
     """Base loader class for individual loaders."""
 
-    def __init__(self, base_path="", structure_dir="structure", content_path="", structure_filename=""):
+    def __init__(self, base_path="", structure_dir="structure", content_path="", structure_filename="", lite_loader=False):
         """Create a BaseLoader object.
 
         Args:
-            base_path: path to content_root, eg. "topics/content/" (str).
-            structure_dir: name of directory under base_path storing structure files (str).
-            content_path: path within locale/structure dir to content directory, eg. "binary-numbers/unit-plan" (str).
-            structure_filename: name of yaml file, eg. "unit-plan.yaml" (str).
+            base_path (str): path to content_root, eg. "topics/content/".
+            structure_dir (str): name of directory under base_path storing structure files.
+            content_path (str): path within locale/structure dir to content directory, eg. "binary-numbers/unit-plan".
+            structure_filename (str): name of yaml file, eg. "unit-plan.yaml".
+            lite_loader (bool): Boolean to state whether loader should only
+                be loading key content and perform minimal checks."
         """
         self.base_path = base_path
         self.structure_dir = structure_dir
         self.content_path = content_path
         self.structure_filename = structure_filename
+        self.lite_loader = lite_loader
         self.setup_md_to_html_converter()
 
     def get_localised_file(self, language, filename):
@@ -144,8 +147,10 @@ class BaseLoader():
 
         if len(result.html_string) == 0:
             raise EmptyMarkdownFileError(md_file_path)
-        check_converter_required_files(result.required_files, md_file_path)
-        check_converter_glossary_links(result.required_glossary_terms, md_file_path)
+
+        if not self.lite_loader:
+            check_converter_required_files(result.required_files, md_file_path)
+            check_converter_glossary_links(result.required_glossary_terms, md_file_path)
         return result
 
     def log(self, message, indent_amount=0):

--- a/csunplugged/utils/BaseLoader.py
+++ b/csunplugged/utils/BaseLoader.py
@@ -25,7 +25,8 @@ from utils.errors.CouldNotFindYAMLFileError import CouldNotFindYAMLFileError
 class BaseLoader():
     """Base loader class for individual loaders."""
 
-    def __init__(self, base_path="", structure_dir="structure", content_path="", structure_filename="", lite_loader=False):
+    def __init__(self, base_path="", structure_dir="structure", content_path="",
+                 structure_filename="", lite_loader=False):
         """Create a BaseLoader object.
 
         Args:


### PR DESCRIPTION
This new development command loads only key content to have faster local development.

The following steps are skipped:

- Loading programming challenges
- Generation of Scratch images
- Creation of search index
- Generation of resource thumbnails

The following timings were run on my home machine so your times may vary, but the performance scale should be roughly the same.

Existing `update` command: 258 seconds (4 minutes and 18 seconds)
New `update_lite` dev command: 40 seconds
Over 6 times faster.

Fixes #1054 