### PR TITLE
Add new deploy scripts to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -93,6 +93,14 @@ jobs:
           skip_cleanup: true
           on:
             branch: develop
+    - script: skip
+      name: "Copy resource PDFs to Google Storage Bucket - Part 6"
+      deploy:
+        - provider: script
+          script: bash ./infrastructure/dev-deploy/deploy-resources-6.sh
+          skip_cleanup: true
+          on:
+            branch: develop
     - stage: production deploy
       script: skip
       name: "Deploy app to Google App Engine"
@@ -155,6 +163,14 @@ jobs:
       deploy:
         - provider: script
           script: bash ./infrastructure/prod-deploy/deploy-resources-5.sh
+          skip_cleanup: true
+          on:
+            branch: master
+    - script: skip
+      name: "Copy resource PDFs to Google Storage Bucket - Part 6"
+      deploy:
+        - provider: script
+          script: bash ./infrastructure/prod-deploy/deploy-resources-6.sh
           skip_cleanup: true
           on:
             branch: master

--- a/infrastructure/dev-deploy/deploy-resources-6.sh
+++ b/infrastructure/dev-deploy/deploy-resources-6.sh
@@ -8,7 +8,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 ./csu update
 
 # Generate static PDF resources for deployment.
-docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter"
+docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Searching Cards"
 
 # Install Google Cloud SDK
 ./infrastructure/install_google_cloud_sdk.sh

--- a/infrastructure/prod-deploy/deploy-resources-5.sh
+++ b/infrastructure/prod-deploy/deploy-resources-5.sh
@@ -9,7 +9,6 @@ source ./infrastructure/prod-deploy/load-prod-deploy-config-envs.sh
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter"
-docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Searching Cards"
 
 # Install Google Cloud SDK
 ./infrastructure/install_google_cloud_sdk.sh

--- a/infrastructure/prod-deploy/deploy-resources-6.sh
+++ b/infrastructure/prod-deploy/deploy-resources-6.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
+source ./infrastructure/prod-deploy/load-prod-deploy-config-envs.sh
 
 # Deploy generated resource files to the development static file server.
 
@@ -8,17 +8,17 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 ./csu update
 
 # Generate static PDF resources for deployment.
-docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter"
+docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Searching Cards"
 
 # Install Google Cloud SDK
 ./infrastructure/install_google_cloud_sdk.sh
 
 # Decrypt secret files archive that contain credentials.
-./infrastructure/dev-deploy/decrypt-dev-secrets.sh
+./infrastructure/prod-deploy/decrypt-prod-secrets.sh
 
 # Authenticate with gcloud tool using the decrypted service account credentials.
 # See: https://cloud.google.com/sdk/gcloud/reference/auth/activate-service-account
-gcloud auth activate-service-account --key-file continuous-deployment-dev.json
+gcloud auth activate-service-account --key-file continuous-deployment-prod.json
 
 # Create empty SSH keys with an empty passphrase, for Google Cloud SDK to
 # copy files to a VM for building the Docker image.
@@ -31,4 +31,4 @@ ssh-keygen -q -N "" -f ~/.ssh/google_compute_engine
 # This copies the generated static files from tests to the Google Storage
 # Bucket.
 # See: https://cloud.google.com/python/django/flexible-environment#deploy_the_app_to_the_app_engine_flexible_environment
-gsutil rsync -R ./csunplugged/staticfiles/resources/ gs://cs-unplugged-dev.appspot.com/static/resources/
+gsutil rsync -R ./csunplugged/staticfiles/resources/ gs://cs-unplugged.appspot.com/static/resources/


### PR DESCRIPTION
Generate the Searching Cards PDF resources in a separate deploy script as the script they are currently generated in is timing out.

In #1254 I added the new scripts but forgot to add them to the `.travis.yml` file. I reverted #1254 in #1255. This PR adds the new scripts _and_ links to them in the travis file.