### PR TITLE
Deprecate 'dev' command for helper script.

### DIFF
--- a/csu
+++ b/csu
@@ -20,22 +20,13 @@ GREEN='\033[0;32m'
 NC='\033[0m' # No Color
 
 cmd_helps=()
-dev_cmd_helps=()
 
 defhelp() {
-  if [ "$1" = '-dev' ]; then
-    local command="${2?}"
-    local text="${3?}"
-    local help_str
-    help_str="$(printf '   %-24s %s' "$command" "$text")"
-    dev_cmd_helps+=("$help_str")
-  else
-    local command="${1?}"
-    local text="${2?}"
-    local help_str
-    help_str="$(printf '   %-24s %s' "$command" "$text")"
-    cmd_helps+=("$help_str")
-  fi
+  local command="${1?}"
+  local text="${2?}"
+  local help_str
+  help_str="$(printf '   %-24s %s' "$command" "$text")"
+  cmd_helps+=("$help_str")
 }
 
 # Print out help information
@@ -49,15 +40,9 @@ cmd_help() {
   for str in "${cmd_helps[@]}"; do
     echo -e "$str"
   done
-  echo
-  echo "DEV_COMMAND list:"
-  for str in "${dev_cmd_helps[@]}"; do
-    echo -e "$str"
-  done
 }
 
 defhelp help 'View all help.'
-defhelp 'dev [DEV_COMMAND]' 'Run a developer command.'
 
 # Start development environment
 cmd_start() {
@@ -92,19 +77,19 @@ defhelp restart 'Stop and then restart development environment.'
 
 # Run Django migrate and updatedata commands
 cmd_update() {
-  dev_static
+  cmd_static
 
   echo ""
-  dev_migrate
+  cmd_migrate
 
   echo ""
-  dev_updatedata
+  cmd_updatedata
 
-  dev_rebuild_index
-  dev_static_scratch
+  cmd_rebuild_index
+  cmd_static_scratch
   echo ""
-  dev_makeresourcethumbnails
-  dev_collect_static
+  cmd_makeresourcethumbnails
+  cmd_collect_static
   echo ""
   echo -e "\n${GREEN}Content is loaded!${NC}"
   echo "Open your preferred web browser to the URL 'localhost'"
@@ -112,135 +97,135 @@ cmd_update() {
 defhelp update 'Run Django migrate and updatedata commands and build static files.'
 
 # Run update command only for key content
-dev_update_lite() {
-  dev_static
+cmd_update_lite() {
+  cmd_static
   echo ""
-  dev_migrate
+  cmd_migrate
   echo ""
   echo "Loading content..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py updatedata --lite-load
-  dev_collect_static
+  cmd_collect_static
   echo ""
   echo -e "\n${GREEN}Key content is loaded!${NC}"
   echo "Run the 'update' command to load all content"
   echo "Open your preferred web browser to the URL 'localhost'"
 }
-defhelp -dev update_lite 'Run update command only for key content - Useful for development.'
+defhelp update_lite 'Run update command only for key content - Useful for development.'
 
 # Collecting static files
-dev_collect_static() {
+cmd_collect_static() {
   echo
   echo "Collecting static files..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py collectstatic --no-input --clear
 }
-defhelp -dev collect_static "Collecting static files."
+defhelp collect_static "Collecting static files."
 
 # Run Django flush command
-dev_flush() {
+cmd_flush() {
   docker-compose exec django /docker_venv/bin/python3 ./manage.py flush
 }
-defhelp -dev flush 'Run Django flush command.'
+defhelp flush 'Run Django flush command.'
 
 # Run Django makemigrations command
-dev_makemigrations() {
+cmd_makemigrations() {
   echo "Creating database migrations..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py makemigrations --no-input
 }
-defhelp -dev makemigrations 'Run Django makemigrations command.'
+defhelp makemigrations 'Run Django makemigrations command.'
 
 # Run Django makeresources command
-dev_makeresources() {
+cmd_makeresources() {
   echo "Creating static resource PDFs..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources
 }
-defhelp -dev makeresources 'Run Django makeresources command.'
+defhelp makeresources 'Run Django makeresources command.'
 
 # Run Django makeresourcethumbnails command
-dev_makeresourcethumbnails() {
+cmd_makeresourcethumbnails() {
   echo "Creating thumbnails for resource PDFs..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresourcethumbnails
 }
-defhelp -dev makeresourcethumbnails 'Run Django makeresourcethumbnails command.'
+defhelp makeresourcethumbnails 'Run Django makeresourcethumbnails command.'
 
 
 # Run Django makemessages command
-dev_makemessages() {
+cmd_makemessages() {
   echo "Creating message files..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py makemessages -l en
 }
-defhelp -dev makemessages 'Run Django makemessages command.'
+defhelp makemessages 'Run Django makemessages command.'
 
 # Run Django compilemessages command
-dev_compilemessages() {
+cmd_compilemessages() {
   echo "Compiling message files..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py compilemessages
 }
-defhelp -dev compilemessages 'Run Django compilemessages command.'
+defhelp compilemessages 'Run Django compilemessages command.'
 
 # Run Django migrate command
-dev_migrate() {
+cmd_migrate() {
   echo "Applying database migrations..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py migrate
 }
-defhelp -dev migrate 'Run Django migrate command.'
+defhelp migrate 'Run Django migrate command.'
 
 # Run Django updatedata command
-dev_updatedata() {
+cmd_updatedata() {
   echo "Loading content..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py updatedata
 }
-defhelp -dev updatedata 'Run updatedata command.'
+defhelp updatedata 'Run updatedata command.'
 
 # Build Docker images
-dev_build() {
+cmd_build() {
   echo "Building Docker images..."
   docker-compose build
 }
-defhelp -dev build 'Build or rebuild Docker images.'
+defhelp build 'Build or rebuild Docker images.'
 
 # Build static files
-dev_static() {
+cmd_static() {
   echo "Building static files..."
   docker-compose exec nginx gulp build
 }
-defhelp -dev static 'Build static files.'
+defhelp static 'Build static files.'
 
 # Build production static files
-dev_static_prod() {
+cmd_static_prod() {
   echo "Building production static files..."
   docker-compose exec nginx gulp build --production
 }
-defhelp -dev static_prod 'Build production static files.'
+defhelp static_prod 'Build production static files.'
 
 # Build scratch static files
-dev_static_scratch() {
+cmd_static_scratch() {
   echo "Building scratch images..."
   docker-compose exec nginx gulp scratch
 }
-defhelp -dev static_scratch "Build scratch images."
+defhelp static_scratch "Build scratch images."
 
 # Run Django command rebuild_index
-dev_rebuild_index() {
+cmd_rebuild_index() {
   echo "Rebuilding search index..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py rebuild_index --noinput
 }
-defhelp -dev rebuild_index "Run Django rebuild_index command."
+defhelp rebuild_index "Run Django rebuild_index command."
 
 # Run shell
-dev_shell() {
+cmd_shell() {
   docker-compose exec django bash
 }
-defhelp -dev shell "Open shell to Django folder."
+defhelp shell "Open shell to Django folder."
 
 # Reboot Django Docker container
-dev_reboot_django() {
+cmd_reboot_django() {
   echo "Rebooting Django Docker container..."
   docker-compose restart django
 }
-defhelp -dev reboot_django 'Reboot Django Docker container.'
+defhelp reboot_django 'Reboot Django Docker container.'
 
 # Run style checks
-dev_style() {
+cmd_style() {
   echo "Running PEP8 style checker..."
   docker-compose exec django /docker_venv/bin/flake8
   pep8_status=$?
@@ -250,39 +235,39 @@ dev_style() {
   pydocstyle_status=$?
   ! (( pep8_status || pydocstyle_status ))
 }
-defhelp -dev style 'Run style checks.'
+defhelp style 'Run style checks.'
 
 # Run test suite
-dev_test_suite() {
+cmd_test_suite() {
   echo "Running test suite..."
   docker-compose exec django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --settings=config.settings.testing --pattern "test_*.py" -v 3 --nomigrations
 }
-defhelp -dev test_suite 'Run test suite with code coverage.'
+defhelp test_suite 'Run test suite with code coverage.'
 
 # Run specific test suite
-dev_test_specific() {
+cmd_test_specific() {
   echo "Running specific test suite..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py test --settings=config.settings.testing "${1}" -v 3 --nomigrations
 }
-defhelp -dev test_specific 'Run specific test suite. Pass in parameter of Python test module.'
+defhelp test_specific 'Run specific test suite. Pass in parameter of Python test module.'
 
 # Display test coverage table
-dev_test_coverage() {
+cmd_test_coverage() {
   echo "Displaying test suite coverage..."
   docker-compose exec django /docker_venv/bin/coverage xml -i
   docker-compose exec django /docker_venv/bin/coverage report -m --skip-covered
 }
-defhelp -dev test_coverage 'Display code coverage report.'
+defhelp test_coverage 'Display code coverage report.'
 
 # Run test suite backwards for CI testing
-dev_test_backwards() {
+cmd_test_backwards() {
   echo "Running test suite backwards..."
   docker-compose exec django /docker_venv/bin/python3 ./manage.py test --settings=config.settings.testing --pattern "test_*.py" --reverse -v 0 --nomigrations
 }
-defhelp -dev test_backwards 'Run test suite backwards.'
+defhelp test_backwards 'Run test suite backwards.'
 
 # Generates the documentation (with warnings as errors)
-dev_docs() {
+cmd_docs() {
   echo "Removing any existing documentation..."
   docker-compose exec django rm -rf /cs-unplugged/docs/build/
   docker-compose exec django mkdir /cs-unplugged/docs/build/
@@ -290,7 +275,7 @@ dev_docs() {
   echo "Creating documentation..."
   docker-compose exec django /docker_venv/bin/sphinx-build -W /cs-unplugged/docs/source/ /cs-unplugged/docs/build/
 }
-defhelp -dev docs 'Generate documentation.'
+defhelp docs 'Generate documentation.'
 
 # Delete all untagged dangling Docker images
 cmd_clean() {
@@ -334,50 +319,50 @@ cmd_logs() {
 defhelp logs 'View logs.'
 
 ci_test_general() {
-  dev_static
-  dev_collect_static
+  cmd_static
+  cmd_collect_static
   docker-compose exec django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --settings=config.settings.testing --pattern "test_*.py" -v 3 --exclude-tag=resource --exclude-tag=management --nomigrations
   test_status=$?
-  dev_test_coverage
+  cmd_test_coverage
   coverage_status=$?
   bash <(curl -s https://codecov.io/bash)
   ! (( $test_status || $coverage_status ))
 }
 
 ci_test_resources() {
-  dev_static
-  dev_collect_static
+  cmd_static
+  cmd_collect_static
   docker-compose exec django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --settings=config.settings.testing --pattern "test_*.py" -v 3 --tag=resource --nomigrations
   test_status=$?
-  dev_test_coverage
+  cmd_test_coverage
   coverage_status=$?
   bash <(curl -s https://codecov.io/bash)
   ! (( $test_status || $coverage_status ))
 }
 
 ci_test_management() {
-  dev_static
-  dev_collect_static
+  cmd_static
+  cmd_collect_static
   docker-compose exec django /docker_venv/bin/coverage run --rcfile=/cs-unplugged/.coveragerc ./manage.py test --settings=config.settings.testing --pattern "test_*.py" -v 3 --tag=management --nomigrations
   test_status=$?
-  dev_test_coverage
+  cmd_test_coverage
   coverage_status=$?
   bash <(curl -s https://codecov.io/bash)
   ! (( $test_status || $coverage_status ))
 }
 
 ci_style() {
-  dev_style
+  cmd_style
 }
 
 ci_test_backwards() {
-  dev_static
-  dev_collect_static
-  dev_test_backwards
+  cmd_static
+  cmd_collect_static
+  cmd_test_backwards
 }
 
 ci_docs() {
-  dev_docs
+  cmd_docs
 }
 
 ci_load_content() {
@@ -411,12 +396,12 @@ cmd_dev() {
   local cmd="$1"
   shift
   if [ -z "$cmd" ]; then
-    echo -e "${RED}ERROR: dev command requires one parameter!${NC}"
+    echo -e "${RED}ERROR: command requires one parameter!${NC}"
     cmd_help
     return 1
   fi
-  if silent type "dev_$cmd"; then
-    "dev_$cmd" "$@"
+  if silent type "cmd_$cmd"; then
+    "cmd_$cmd" "$@"
     exit $?
   else
     echo -e "${RED}ERROR: Unknown command!${NC}"

--- a/docs/source/developer/test_suite.rst
+++ b/docs/source/developer/test_suite.rst
@@ -8,7 +8,7 @@ Test Suite
 Running the Test Suite
 ==============================================================================
 
-``./csu dev test`` will run the entire test suite. For running a specific tests, viewing code coverage, and more testing commands, see :doc:`../getting_started/helper_commands`.
+``./csu test_suite`` will run the entire test suite. For running a specific tests, viewing code coverage, and more testing commands, see :doc:`../getting_started/helper_commands`.
 
 
 Structure

--- a/docs/source/getting_started/helper_commands.rst
+++ b/docs/source/getting_started/helper_commands.rst
@@ -3,20 +3,12 @@ Helper Commands for Developing
 
 .. note::
 
-  We assume by this point you have installed the project, checked the
-  setup is working (see :ref:`installation-check-project-setup-works`),
-  and also have a basic understanding of the
-  :doc:`project structure <project_structure>`.
+  We assume by this point you have installed the project, checked the setup is working (see :ref:`installation-check-project-setup-works`), and also have a basic understanding of the :doc:`project structure <project_structure>`.
 
-The CS Unplugged project uses many systems (Django, Docker, Gulp, etc) to run,
-so we have written a script for running groups of commands for running the
-system while developing.
+The CS Unplugged project uses many systems (Django, Docker, Gulp, etc) to run, so we have written a script for running groups of commands for running the system while developing.
 
-The script is called ``csu`` and can be found in the ``cs-unplugged`` folder
-of the repository.
-To run this script, open a terminal window in the directory and enter the
-following command (you don't need to enter the ``$`` character, this shows
-the start of your terminal prompt):
+The script is called ``csu`` and can be found in the ``cs-unplugged`` folder of the repository.
+To run this script, open a terminal window in the directory and enter the following command (you don't need to enter the ``$`` character, this shows the start of your terminal prompt):
 
 .. code-block:: bash
 
@@ -26,23 +18,42 @@ Where ``[COMMAND]`` is a word from the list below:
 
 - :ref:`build`
 - :ref:`clean`
-- :ref:`dev`
+- :ref:`collect_static`
+- :ref:`compilemessages`
+- :ref:`docs`
 - :ref:`end`
+- :ref:`flush`
 - :ref:`help`
+- :ref:`logs`
+- :ref:`makemessages`
+- :ref:`makemigrations`
+- :ref:`makeresources`
+- :ref:`makeresourcethumbnails`
+- :ref:`migrate`
+- :ref:`reboot_django`
+- :ref:`rebuild_index`
 - :ref:`restart`
+- :ref:`shell`
 - :ref:`start`
+- :ref:`static`
+- :ref:`static_prod`
+- :ref:`static_scratch`
+- :ref:`style`
+- :ref:`test_backwards`
+- :ref:`test_coverage`
+- :ref:`test_specific`
+- :ref:`test_suite`
 - :ref:`update`
+- :ref:`updatedata`
+- :ref:`update_lite`
 - :ref:`wipe`
 
-All users of the project (content and technical developers) should become
-familiar with the following commands:
+All users of the project (content and technical developers) should become familiar with the following commands:
 
 - :ref:`start`
 - :ref:`end`
 - :ref:`build`
 - :ref:`update`
-
-Technical developers should also understand the ``dev`` command.
 
 -----------------------------------------------------------------------------
 
@@ -51,8 +62,7 @@ Technical developers should also understand the ``dev`` command.
 ``build``
 ==============================================================================
 
-Running ``./csu build`` will build or rebuild the Docker images that are
-required for the CS Unplugged system.
+Running ``./csu build`` will build or rebuild the Docker images that are required for the CS Unplugged system.
 
 -----------------------------------------------------------------------------
 
@@ -61,171 +71,37 @@ required for the CS Unplugged system.
 ``clean``
 ==============================================================================
 
-Running ``./csu clean`` deletes 'dangling' Docker images left over from builds,
-which will free up hard drive space.
+Running ``./csu clean`` deletes 'dangling' Docker images left over from builds, which will free up hard drive space.
 
 -----------------------------------------------------------------------------
 
-.. _dev:
+.. _collect_static:
 
-``dev``
+``collect_static``
 ==============================================================================
 
-The ``./csu dev [DEV_COMMAND]`` command runs developer tasks, where
-``[DEV_COMMAND]`` is a word from the list below:
+Running ``./csu collect_static`` runs the Django ``collectstatic`` command to collect static files.
+It will copy files under the ``static/`` folder into the ``staticfiles/`` folder.
 
-- :ref:`logs`
-- :ref:`flush`
-- :ref:`makemigrations`
-- :ref:`makeresources`
-- :ref:`migrate`
-- :ref:`rebuild_index`
-- :ref:`shell`
-- :ref:`static`
-- :ref:`static_prod`
-- :ref:`style`
-- :ref:`test`
-- :ref:`test_backwards`
-- :ref:`test_coverage`
-- :ref:`test_specific`
-- :ref:`updatedata`
-
-.. _logs:
-
-``logs``
 -----------------------------------------------------------------------------
 
-Running ``./csu dev logs`` will display the logs for the running systems.
-The output is for all logs until the time the command was run, therefore
-successive calls may display new logs.
+.. _compilemessages:
 
-To follow logs as they output, enter ``docker-compose logs --follow``.
+``compilemessages``
+==============================================================================
 
-.. _flush:
+Running ``./csu compilemessages`` runs the Django ``compilemessages`` command.
+This runs over ``.po`` files and creates ``.mo`` files which are optimised for use by ``gettext``.
+You will need to run this command after each time you create your message file or each time you make changes to it.
 
-``flush``
 -----------------------------------------------------------------------------
 
-Running ``./csu dev flush`` runs the Django ``flush`` command to flush
-the database.
+.. _docs:
 
-.. _makemigrations:
+``docs``
+==============================================================================
 
-``makemigrations``
------------------------------------------------------------------------------
-
-Running ``./csu dev makemigrations`` runs the Django ``makemigrations`` command
-to create migration files.
-
-.. _makeresources:
-
-``makeresources``
------------------------------------------------------------------------------
-
-Running ``./csu dev makeresources`` runs the custom Django ``makeresources``
-command to create static resource PDF files.
-
-.. _migrate:
-
-``migrate``
------------------------------------------------------------------------------
-
-Running ``./csu dev migrate`` runs the Django ``migrate`` command
-to apply migration files.
-
-.. _rebuild_index:
-
-``rebuild_index``
------------------------------------------------------------------------------
-
-Running ``./csu dev rebuild_index`` runs the Haystack ``rebuild_index`` Django
-command.
-
-.. _shell:
-
-``shell``
------------------------------------------------------------------------------
-
-Running ``./csu dev shell`` opens a bash terminal within the Django container
-(this requires the CS Unplugged system to be running).
-
-This is the equivalent to entering ``docker-compose run django bash``.
-
-.. _static:
-
-``static``
------------------------------------------------------------------------------
-
-Running ``./csu dev static`` runs the commands for generating the static files
-for the website.
-
-If changes are made to the static files (for example, a new image is added)
-when the system is running, this command needs to be entered to view the
-new files on the website.
-
-.. _static_prod:
-
-``static_prod``
------------------------------------------------------------------------------
-
-Running ``./csu dev static_prod`` runs the commands for generating production
-static files for the website.
-This produces compressed SASS files without sourcemaps.
-
-.. _style:
-
-``style``
------------------------------------------------------------------------------
-
-Running ``./csu dev style`` will run the ``flake8`` and ``pydocstyle`` commands
-to check the style of the project.
-If the output is ``0`` for a check, then there are zero errors.
-
-.. _test:
-
-``test``
------------------------------------------------------------------------------
-
-Running ``./csu dev test`` will run the test suite, and create a report
-detailing test code coverage.
-The code coverage report can be displayed by running
-``./csu dev test_coverage``.
-
-.. _test_backwards:
-
-``test_backwards``
------------------------------------------------------------------------------
-
-Running ``./csu dev test_backwards`` will run the test suite in reverse.
-This is useful to check if any tests are influencing the result of each other.
-If this command if run on Travis CI, it will only run for a pull request.
-
-.. _test_coverage:
-
-``test_coverage``
------------------------------------------------------------------------------
-
-Running ``./csu dev test_coverage`` will display a table detailing test code
-coverage, from the report generated by ``./csu dev test``.
-
-.. _test_specific:
-
-``test_specific``
------------------------------------------------------------------------------
-
-Running ``./csu dev test_specific [MODULE_PATH]`` will run a specific test
-module.
-For example, running
-``./csu dev test_specific tests.resources.views.test_index_view`` will only
-run the tests for checking the index view of the resources application.
-
-.. _updatedata:
-
-``updatedata``
------------------------------------------------------------------------------
-
-Running ``./csu dev updatedata`` runs the custom ``updatedata`` command to
-load the topics content into the database.
+Running ``./csu docs`` will remove any existing documentation and build a fresh copy of the documentation for CS Unplugged.
 
 -----------------------------------------------------------------------------
 
@@ -234,8 +110,16 @@ load the topics content into the database.
 ``end``
 ==============================================================================
 
-Running ``./csu end`` will stop any containers which are currently running,
-this usually takes 10 to 20 seconds.
+Running ``./csu end`` will stop any containers which are currently running, this usually takes 10 to 20 seconds.
+
+-----------------------------------------------------------------------------
+
+.. _flush:
+
+``flush``
+==============================================================================
+
+Running ``./csu flush`` runs the Django ``flush`` command to flush the database.
 
 -----------------------------------------------------------------------------
 
@@ -246,6 +130,83 @@ this usually takes 10 to 20 seconds.
 
 Running ``./csu help`` displays brief help text for the script.
 More details for each command can be found on this page.
+
+-----------------------------------------------------------------------------
+
+.. _logs:
+
+``logs``
+==============================================================================
+
+Running ``./csu logs`` will display the logs for the running systems.
+The output is for all logs until the time the command was run, therefore successive calls may display new logs.
+
+To follow logs as they output, enter ``docker-compose logs --follow``.
+
+-----------------------------------------------------------------------------
+
+.. _makemessages:
+
+``makemessages``
+==============================================================================
+
+Running ``./csu makemessages`` runs the Djanog ``makemessages`` command.
+This will create message files where each message file represents a single language.
+Message files contain all available translation strings and how they should be represented in the given language.
+
+-----------------------------------------------------------------------------
+
+.. _makemigrations:
+
+``makemigrations``
+==============================================================================
+
+Running ``./csu makemigrations`` runs the Django ``makemigrations`` command to create migration files.
+
+-----------------------------------------------------------------------------
+
+.. _makeresources:
+
+``makeresources``
+==============================================================================
+
+Running ``./csu makeresources`` runs the custom Django ``makeresources`` command to create static resource PDF files.
+
+-----------------------------------------------------------------------------
+
+.. _makeresourcethumbnails:
+
+``makeresourcethumbnails``
+==============================================================================
+
+Running ``./csu makeresourcethumbnails`` generates the thumbnails for each resource PDF.
+
+-----------------------------------------------------------------------------
+
+.. _migrate:
+
+``migrate``
+==============================================================================
+
+Running ``./csu migrate`` runs the Django ``migrate`` command to apply migration files.
+
+-----------------------------------------------------------------------------
+
+.. _reboot_django:
+
+``reboot_django``
+==============================================================================
+
+Running ``./csu reboot_django`` will rebuild the Django Docker container.
+
+-----------------------------------------------------------------------------
+
+.. _rebuild_index:
+
+``rebuild_index``
+==============================================================================
+
+Running ``./csu rebuild_index`` runs the Haystack ``rebuild_index`` Django command.
 
 -----------------------------------------------------------------------------
 
@@ -263,31 +224,116 @@ More details for each command can be found on this page.
 
 -----------------------------------------------------------------------------
 
+.. _shell:
+
+``shell``
+==============================================================================
+
+Running ``./csu shell`` opens a bash terminal within the Django container (this requires the CS Unplugged system to be running).
+
+This is the equivalent to entering ``docker-compose run django bash``.
+
+-----------------------------------------------------------------------------
+
 .. _start:
 
 ``start``
 ==============================================================================
 
-Running ``./csu start`` starts the development environment. It performs the
-following tasks:
+Running ``./csu start`` starts the development environment.
+It performs the following tasks:
 
 - Build system Docker images if required (see below)
 - Start the Django website system
 - Start the Nginx server to display the website and static files
 - Start the database server
 
-When you run this command for the first time on a computer it will also run
-``./csu build`` to build the system Docker images.
-This can take some time, roughly 15 to 30 minutes, depending on your computer
-and internet speed.
-Images are only required to be built once, unless the image specifications
-change (you can rebuild the images with ``./csu build``).
+When you run this command for the first time on a computer it will also run ``./csu build`` to build the system Docker images.
+This can take some time, roughly 15 to 30 minutes, depending on your computer and internet speed.
+Images are only required to be built once, unless the image specifications change (you can rebuild the images with ``./csu build``).
 Once the images are built, the script will run these images in containers.
 
-Once the development environment is operational, run the ``./csu update``
-command to load the CS Unplugged content.
+Once the development environment is operational, run the ``./csu update`` command to load the CS Unplugged content.
 
+-----------------------------------------------------------------------------
 
+.. _static:
+
+``static``
+==============================================================================
+
+Running ``./csu static`` runs the commands for generating the static files for the website.
+
+If changes are made to the static files (for example, a new image is added) when the system is running, this command needs to be entered to view the new files on the website.
+
+-----------------------------------------------------------------------------
+
+.. _static_prod:
+
+``static_prod``
+==============================================================================
+
+Running ``./csu static_prod`` runs the commands for generating production static files for the website.
+This produces compressed SASS files without sourcemaps.
+
+-----------------------------------------------------------------------------
+
+.. _static_scratch:
+
+``static_scratch``
+==============================================================================
+
+Running ``./csu static_scratch`` runs the commands for generating scratch images for the website.
+
+-----------------------------------------------------------------------------
+
+.. _style:
+
+``style``
+==============================================================================
+
+Running ``./csu style`` will run the ``flake8`` and ``pydocstyle`` commands to check the style of the project.
+If the output is ``0`` for a check, then there are zero errors.
+
+-----------------------------------------------------------------------------
+
+.. _test_backwards:
+
+``test_backwards``
+==============================================================================
+
+Running ``./csu test_backwards`` will run the test suite in reverse.
+This is useful to check if any tests are influencing the result of each other.
+If this command if run on Travis CI, it will only run for a pull request.
+
+-----------------------------------------------------------------------------
+
+.. _test_coverage:
+
+``test_coverage``
+==============================================================================
+
+Running ``./csu test_coverage`` will display a table detailing test code coverage, from the report generated by ``./csu test``.
+
+-----------------------------------------------------------------------------
+
+.. _test_specific:
+
+``test_specific``
+==============================================================================
+
+Running ``./csu test_specific [MODULE_PATH]`` will run a specific test module.
+For example, running ``./csu test_specific tests.resources.views.test_index_view`` will only run the tests for checking the index view of the resources application.
+
+-----------------------------------------------------------------------------
+
+.. _test_suite:
+
+``test_suite``
+==============================================================================
+
+Running ``./csu test_suite`` will run the test suite, and create a report detailing test code coverage.
+The code coverage report can be displayed by running ``./csu test_coverage``.
 
 -----------------------------------------------------------------------------
 
@@ -302,17 +348,32 @@ Running ``./csu update`` performs the following tasks:
 - Load the CS Unplugged content into the database
 - Create the required static files
 
-Once the script has performed all these tasks, the script will let you know
-the website is ready.
+Once the script has performed all these tasks, the script will let you know the website is ready.
 Open your preferred web browser to the URL ``localhost`` to view the website.
 
-In more detail, ``./csu update`` runs the Django ``makemigratations`` and ``migrate``
-commands for updating the database schema, and then runs the custom
-``updatedata`` command to load the topics content into the database.
+In more detail, ``./csu update`` runs the Django ``makemigratations`` and ``migrate`` commands for updating the database schema, and then runs the custom ``updatedata`` command to load the topics content into the database.
 It also runs the ``static`` command to generate static files.
 
-If changes are made to the topics content when the system is running, this
-command needs to be run to view the new changes on the website.
+If changes are made to the topics content when the system is running, this command needs to be run to view the new changes on the website.
+
+-----------------------------------------------------------------------------
+
+.. _updatedata:
+
+``updatedata``
+==============================================================================
+
+Running ``./csu updatedata`` runs the custom ``updatedata`` command to load the topics content into the database.
+
+-----------------------------------------------------------------------------
+
+.. _update_lite:
+
+``update_lite``
+==============================================================================
+
+Running ``./csu update_lite`` only loads key content.
+Useful for development.
 
 -----------------------------------------------------------------------------
 
@@ -322,14 +383,10 @@ command needs to be run to view the new changes on the website.
 ==============================================================================
 
 Running ``./csu wipe`` delete all Docker containers and images on your computer.
-Once this command has be run, a full download and rebuild of images is
-required to run the system (can be triggered by the ``build`` or ``start``
-commands).
+Once this command has be run, a full download and rebuild of images is required to run the system (can be triggered by the ``build`` or ``start`` commands).
 
 -----------------------------------------------------------------------------
 
 You now know the basic commands for using the CS Unplugged system.
-You are now ready to tackle the documentation for the area you wish to
-contribute on.
-Head back to the :doc:`documentation homepage <../index>` and choose the documentation related
-to the task you wish to contribute to.
+You are now ready to tackle the documentation for the area you wish to contribute on.
+Head back to the :doc:`documentation homepage <../index>` and choose the documentation related to the task you wish to contribute to.


### PR DESCRIPTION
This PR modifies the `csu` script such that `dev` commands can now be run without the `dev` prefix. However if commands are given with `dev` they will still work.

Reason for deprecation: 
Only developers use this script anyway and it is annoying if we get into the habit of using `dev` and then a command won't run because we accidentally included the dev prefix when it wasn't expecting it.

Resolves #466 