### PR TITLE
Parallelise makeresource commands

### DIFF
--- a/csunplugged/resources/utils/BaseResourceGenerator.py
+++ b/csunplugged/resources/utils/BaseResourceGenerator.py
@@ -166,6 +166,10 @@ class BaseResourceGenerator(ABC):
         """
         # Only import weasyprint when required as production environment
         # does not have it installed.
+        # Also adapt logging so that weasyprint doesn't print warnings when it detects unknown css properties:
+        import logging
+        logger = logging.getLogger("weasyprint").setLevel(100)
+
         from weasyprint import HTML, CSS
         context = dict()
         context["resource"] = resource_name
@@ -247,6 +251,10 @@ class BaseResourceGenerator(ABC):
         """
         # Only import weasyprint when required as production environment
         # does not have it installed.
+        # Also adapt logging so that weasyprint doesn't print warnings when it detects unknown css properties:
+        import logging
+        logger = logging.getLogger("weasyprint").setLevel(100)
+
         from weasyprint import HTML, CSS
         context = dict()
         context["resource"] = resource_name

--- a/infrastructure/dev-deploy/deploy-resources-1.sh
+++ b/infrastructure/dev-deploy/deploy-resources-1.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Arrows"

--- a/infrastructure/dev-deploy/deploy-resources-10.sh
+++ b/infrastructure/dev-deploy/deploy-resources-10.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter" "mi"

--- a/infrastructure/dev-deploy/deploy-resources-11.sh
+++ b/infrastructure/dev-deploy/deploy-resources-11.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter" "zh-hans"

--- a/infrastructure/dev-deploy/deploy-resources-2.sh
+++ b/infrastructure/dev-deploy/deploy-resources-2.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Modulo Clock"

--- a/infrastructure/dev-deploy/deploy-resources-3.sh
+++ b/infrastructure/dev-deploy/deploy-resources-3.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Sorting Network"

--- a/infrastructure/dev-deploy/deploy-resources-4.sh
+++ b/infrastructure/dev-deploy/deploy-resources-4.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Number Hunt" "en"

--- a/infrastructure/dev-deploy/deploy-resources-5.sh
+++ b/infrastructure/dev-deploy/deploy-resources-5.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Number Hunt" "mi"

--- a/infrastructure/dev-deploy/deploy-resources-6.sh
+++ b/infrastructure/dev-deploy/deploy-resources-6.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Searching Cards"

--- a/infrastructure/dev-deploy/deploy-resources-7.sh
+++ b/infrastructure/dev-deploy/deploy-resources-7.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter" "en"

--- a/infrastructure/dev-deploy/deploy-resources-8.sh
+++ b/infrastructure/dev-deploy/deploy-resources-8.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter" "de"

--- a/infrastructure/dev-deploy/deploy-resources-9.sh
+++ b/infrastructure/dev-deploy/deploy-resources-9.sh
@@ -5,7 +5,7 @@ source ./infrastructure/dev-deploy/load-dev-deploy-config-envs.sh
 # Deploy generated resource files to the development static file server.
 
 ./csu start
-./csu update
+./csu update_lite
 
 # Generate static PDF resources for deployment.
 docker-compose exec django /docker_venv/bin/python3 ./manage.py makeresources "Pixel Painter" "es"


### PR DESCRIPTION
## The problem:

- The problem this intends to help is that the `makeresources` command, which generates PDFs (Printables) for resources, takes so long that the task needs to be split into 11 different jobs on Travis.
  - Further overhead is created with each new job; the system needs to be built and started on each job before the required bit of work can be done.

### Main Changes:

- Partially parallelise the `makeresources` command
- Switch to `update_lite` instead of `update` for making resources in _dev_deploy_ scripts
(_prod_deploy_ is unchanged presently)

### Secondary Changes:

- Apply the same partial parallelisation technique to the `makeresourcethumbnails` command (resolves #855)
- Stop unnecessary output from Weasyprint

### Effects:

**On my PC (6c12t) using 6 threads**

- ~30% reduction in the time to complete the full `makeresources` command (details below)
- ~50% reduction in the time to complete the full `makeresourcethumbnails` command
- ~35% reduction in the time to complete the full `update` command
- I don't see any changes to the final result

![image](https://user-images.githubusercontent.com/25916475/72763597-5421c580-3c49-11ea-9ffd-25e2bdc25f25.png)

- Six resources threw an `sqlite3.ProgrammingError` when attempting to run over multiple threads. I couldn't figure why these 6 had an sqlite3 object that the others didn't have, so I added code that reverted to processing in series when a problem was detected. Further improvements should be possible if we can get a nicer solution.
- The `Binary to Alphabet` resource is the only one that is successfully parallelised yet takes longer to generate. I suspect that this is because it is CPU bound, whereas the others would be I/O bound and therefore benefit from the Python implementation of multithreading.

## Travis

**Sadly I have no way to check in advance how any of these changes will affect our actual deployment**

- Using `update_lite` instead of `update` should save over 3 minutes per job
- I have changed nothing else with the deployment settings; I want to see how these changes affect the existing jobs before attempting to rearrange them
- [From what I can find](https://docs.travis-ci.com/user/reference/overview/#virtualisation-environment-vs-operating-system), Travis only uses 2 cores per job, whereas my PC has 6. I'm concerned that this will result in a significantly smaller improvement, and I may need to reduce the number of assigned threads. The performance on Travis will also depend on its I/O capacity.