### PR TITLE
Educators programming table collapsible content

### DIFF
--- a/csunplugged/static/scss/challenges-list.scss
+++ b/csunplugged/static/scss/challenges-list.scss
@@ -1,0 +1,16 @@
+.educators-programming-challenge-number {
+    font-size: 1.2rem;
+}
+        .acc-programming-challenge {
+    padding: 0.75rem;
+}
+.badge-outline {
+    color: #3366ff;
+    background-color: transparent;
+    border: 1px solid #3366ff;
+}
+.badge-outline:hover {
+    color: white;
+    background-color: #3366ff;
+    cursor: pointer;
+}

--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -844,3 +844,12 @@ button:hover .icon-search {
     max-height: 60vh;
     object-fit: contain;
 }
+.badge-outline {
+  color: #3366ff;
+  background-color: transparent;
+  border: 1px solid #3366ff;
+}
+.badge-outline:hover {
+  color: white;
+  background-color: #3366ff;
+}

--- a/csunplugged/static/scss/website.scss
+++ b/csunplugged/static/scss/website.scss
@@ -844,12 +844,3 @@ button:hover .icon-search {
     max-height: 60vh;
     object-fit: contain;
 }
-.badge-outline {
-  color: #3366ff;
-  background-color: transparent;
-  border: 1px solid #3366ff;
-}
-.badge-outline:hover {
-  color: white;
-  background-color: #3366ff;
-}

--- a/csunplugged/templates/topics/programming-challenge-lesson-list.html
+++ b/csunplugged/templates/topics/programming-challenge-lesson-list.html
@@ -27,7 +27,7 @@
   {% if programming_challenges %}
     <div class="custom-control custom-checkbox py-3">
       <input type="checkbox" class="custom-control-input" id="show-all-checkbox">
-      <label class="custom-control-label" for="show-all-checkbox">Check to show all detailed content</label>
+      <label class="custom-control-label" for="show-all-checkbox">{% trans "Check to show all detailed content" %}</label>
     </div>
     {% include "topics/programming-challenges-table.html" %}
   {% else %}
@@ -41,8 +41,10 @@
     $("#show-all-checkbox").change(function() {
         if (this.checked) {
           $('.acc-programming-challenge').collapse('show')
+          $(".toggle-content").text('Show less details');
         } else {
           $('.acc-programming-challenge').collapse('hide')
+          $(".toggle-content").text('Show more details');
         }
     });
   </script>

--- a/csunplugged/templates/topics/programming-challenge-lesson-list.html
+++ b/csunplugged/templates/topics/programming-challenge-lesson-list.html
@@ -25,8 +25,25 @@
   {% endif %}
 
   {% if programming_challenges %}
+    <div class="custom-control custom-checkbox py-3">
+      <input type="checkbox" class="custom-control-input" id="show-all-checkbox">
+      <label class="custom-control-label" for="show-all-checkbox">Check to show all detailed content</label>
+    </div>
     {% include "topics/programming-challenges-table.html" %}
   {% else %}
     <p>{% blocktrans trimmed %}No programming challenges for {{ topic }}.{% endblocktrans %}</p>
   {% endif %}
 {% endblock content %}
+
+{% block scripts %}
+  <script type="text/javascript">
+    // This ensures all are closed and all are opened, otherwise wierd toggling behavior occurs.
+    $("#show-all-checkbox").change(function() {
+        if (this.checked) {
+          $('.acc-programming-challenge').collapse('show')
+        } else {
+          $('.acc-programming-challenge').collapse('hide')
+        }
+    });
+  </script>
+{% endblock scripts %}

--- a/csunplugged/templates/topics/programming-challenges-table.html
+++ b/csunplugged/templates/topics/programming-challenges-table.html
@@ -57,6 +57,16 @@
                 </ul>
               </div>
             {% endif %}
+
+            {% if programming_challenge.ordered_implementations %}
+              <strong>{% trans "Challenge Solutions" %}</strong>
+            {% endif %}
+            {% for implementation in programming_challenge.ordered_implementations %}
+              </br>
+              <a href="{% url 'topics:programming_challenge_solution' topic.slug programming_challenge.slug implementation.language.slug %}">
+                  Show {{ implementation.language.name }} solution
+              </a> 
+            {% endfor %}
           </div>
       </td>
     </tr>

--- a/csunplugged/templates/topics/programming-challenges-table.html
+++ b/csunplugged/templates/topics/programming-challenges-table.html
@@ -2,80 +2,97 @@
 
 {% load i18n %}
 
-<table class="table table-responsive table-center-vertical">
-  <thead class="thead-default">
-    <tr>
-      <th class="text-center">{% trans "Number" %}</th>
-      <th>{% trans "Name" %}</th>
-      <th class="text-center">{% trans "Challenge Level" %}</th>
-      <th class="text-center">{% trans "Languages" %}</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for programming_challenge in programming_challenges %}
-    <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %}">
-      <td class="text-center">
-        <strong style="font-size: 20px">
-          {{ programming_challenge.challenge_set_number }}.{{ programming_challenge.challenge_number }}
-        </strong>
-      </td>
-      <td>
-        {% if not programming_challenge.translation_available %}
-          {% include "generic/not-available-badge.html" %}
-          <br>
-        {% endif %}
-        <a href="{% url 'topics:programming_challenge' topic.slug programming_challenge.slug %}">
-          <strong>
-            {{ programming_challenge.name }}
+<div class="table-responsive" >
+  <table class="table table-center-vertical">
+    <thead class="thead-default">
+      <tr>
+        <th class="text-center">{% trans "Number" %}</th>
+        <th>{% trans "Name" %}</th>
+        <th class="text-center">{% trans "Challenge Level" %}</th>
+        <th class="text-center">{% trans "Languages" %}</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for programming_challenge in programming_challenges %}
+      <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %}">
+        <td class="text-center">
+          <strong class="educators-programming-challenge-number">
+            {{ programming_challenge.challenge_set_number }}.{{ programming_challenge.challenge_number }}
           </strong>
-        </a>
-        <br>
-        <a href="#" class="badge badge-outline" data-toggle="collapse" data-target="#accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}">
-          Show more details
-        </a>
-      </td>
-      <td class="text-center">
-        {% include "topics/programming-difficulty-badge.html" %}
-      </td>
-      <td class="text-center">
-        {% for implementation in programming_challenge.ordered_implementations %}
-          <img src="{% get_static_prefix %}{{ implementation.language.icon }}" class="inline-image-small" />
-        {% endfor %}
-      </td>
-    </tr>
-    <tr>
-      <td class="p-0"></td>
-      <td colspan="3"  class="p-0">
-          <div id="accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" style="padding: 0.75rem" class="collapse acc-programming-challenge">
-            {% if programming_challenge.get_learning_outcomes %}
-              <strong>{% trans "Learning outcomes" %}</strong>
-              <div class="boxed-text-content">
-                <p>{% trans "Students will be able to:" %}</p>
-                <ul>
-                  {% for learning_outcome in programming_challenge.get_learning_outcomes %}
-                  <li>
-                    {{ learning_outcome.text }}<br>
-                    {% for area in learning_outcome.curriculum_areas.all %}
-                      {% include "topics/curriculum-area-badge.html" %}
+        </td>
+        <td>
+          {% if not programming_challenge.translation_available %}
+            {% include "generic/not-available-badge.html" %}
+            <br>
+          {% endif %}
+          <a href="{% url 'topics:programming_challenge' topic.slug programming_challenge.slug %}">
+            <strong>
+              {{ programming_challenge.name }}
+            </strong>
+          </a>
+          <br>
+          <span id="toggle-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" onclick="updateToggleButtonText({{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }})" class="badge badge-outline toggle-content collapsed" data-toggle="collapse" data-target="#accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}">
+            {% trans "Show more details" %}
+          </span>
+        </td>
+        <td class="text-center">
+          {% include "topics/programming-difficulty-badge.html" %}
+        </td>
+        <td class="text-center">
+          {% for implementation in programming_challenge.ordered_implementations %}
+            <img src="{% get_static_prefix %}{{ implementation.language.icon }}" class="inline-image-small" />
+          {% endfor %}
+        </td>
+      </tr>
+      <tr>
+        <td class="p-0"></td>
+        <td colspan="3"  class="p-0">
+            <div id="accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" class="collapse acc-programming-challenge">
+              {% if programming_challenge.get_learning_outcomes %}
+                <strong>{% trans "Learning outcomes" %}</strong>
+                <div class="boxed-text-content">
+                  <p>{% trans "Students will be able to:" %}</p>
+                  <ul>
+                    {% for learning_outcome in programming_challenge.get_learning_outcomes %}
+                    <li>
+                      {{ learning_outcome.text }}<br>
+                      {% for area in learning_outcome.curriculum_areas.all %}
+                        {% include "topics/curriculum-area-badge.html" %}
+                      {% endfor %}
+                    </li>
                     {% endfor %}
-                  </li>
-                  {% endfor %}
-                </ul>
-              </div>
-            {% endif %}
+                  </ul>
+                </div>
+              {% endif %}
 
-            {% if programming_challenge.ordered_implementations %}
-              <strong>{% trans "Challenge Solutions" %}</strong>
-            {% endif %}
-            {% for implementation in programming_challenge.ordered_implementations %}
-              </br>
-              <a href="{% url 'topics:programming_challenge_solution' topic.slug programming_challenge.slug implementation.language.slug %}">
-                  Show {{ implementation.language.name }} solution
-              </a> 
-            {% endfor %}
-          </div>
-      </td>
-    </tr>
-    {% endfor %}
-  </tbody>
-</table>
+              {% if programming_challenge.ordered_implementations %}
+                <strong>{% trans "Challenge Solutions" %}</strong>
+              {% endif %}
+              {% for implementation in programming_challenge.ordered_implementations %}
+                </br>
+                <a href="{% url 'topics:programming_challenge_solution' topic.slug programming_challenge.slug implementation.language.slug %}">
+                    {% blocktrans with name=implementation.language.name %}Show {{ name }} solution{% endblocktrans %}
+                </a> 
+              {% endfor %}
+            </div>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+
+{% block scripts %}
+  <link rel="stylesheet" href="{% static 'css/challenges-list.css' %}" >
+  <script type="text/javascript">
+    function updateToggleButtonText(challenge_num) {
+      challengeContentToggleId = `#toggle-${challenge_num}`;
+      if ($(challengeContentToggleId).hasClass('collapsed')) {
+        $(challengeContentToggleId).text('Show less details');
+      } else {
+        $(challengeContentToggleId).text('Show more details');
+      }
+    }
+  </script>
+{% endblock scripts %}
+

--- a/csunplugged/templates/topics/programming-challenges-table.html
+++ b/csunplugged/templates/topics/programming-challenges-table.html
@@ -13,9 +13,11 @@
   </thead>
   <tbody>
     {% for programming_challenge in programming_challenges %}
-    <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %} clickable" data-toggle="collapse" data-target="#accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}">
+    <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %}">
       <td class="text-center">
-        {{ programming_challenge.challenge_set_number }}.{{ programming_challenge.challenge_number }}
+        <strong style="font-size: 20px">
+          {{ programming_challenge.challenge_set_number }}.{{ programming_challenge.challenge_number }}
+        </strong>
       </td>
       <td>
         {% if not programming_challenge.translation_available %}
@@ -26,6 +28,10 @@
           <strong>
             {{ programming_challenge.name }}
           </strong>
+        </a>
+        <br>
+        <a href="#" class="badge badge-outline" data-toggle="collapse" data-target="#accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}">
+          Show more details
         </a>
       </td>
       <td class="text-center">
@@ -40,7 +46,7 @@
     <tr>
       <td class="p-0"></td>
       <td colspan="3"  class="p-0">
-          <div id="accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" style="padding: 0.75rem" class="collapse">
+          <div id="accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" style="padding: 0.75rem" class="collapse acc-programming-challenge">
             {% if programming_challenge.get_learning_outcomes %}
               <strong>{% trans "Learning outcomes" %}</strong>
               <div class="boxed-text-content">

--- a/csunplugged/templates/topics/programming-challenges-table.html
+++ b/csunplugged/templates/topics/programming-challenges-table.html
@@ -13,7 +13,7 @@
   </thead>
   <tbody>
     {% for programming_challenge in programming_challenges %}
-    <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %}">
+    <tr class="align-middle{% if not programming_challenge.translation_available %} table-active{% endif %} clickable" data-toggle="collapse" data-target="#accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}">
       <td class="text-center">
         {{ programming_challenge.challenge_set_number }}.{{ programming_challenge.challenge_number }}
       </td>
@@ -35,6 +35,29 @@
         {% for implementation in programming_challenge.ordered_implementations %}
           <img src="{% get_static_prefix %}{{ implementation.language.icon }}" class="inline-image-small" />
         {% endfor %}
+      </td>
+    </tr>
+    <tr>
+      <td class="p-0"></td>
+      <td colspan="3"  class="p-0">
+          <div id="accordion-{{ programming_challenge.challenge_set_number }}{{ programming_challenge.challenge_number }}" style="padding: 0.75rem" class="collapse">
+            {% if programming_challenge.get_learning_outcomes %}
+              <strong>{% trans "Learning outcomes" %}</strong>
+              <div class="boxed-text-content">
+                <p>{% trans "Students will be able to:" %}</p>
+                <ul>
+                  {% for learning_outcome in programming_challenge.get_learning_outcomes %}
+                  <li>
+                    {{ learning_outcome.text }}<br>
+                    {% for area in learning_outcome.curriculum_areas.all %}
+                      {% include "topics/curriculum-area-badge.html" %}
+                    {% endfor %}
+                  </li>
+                  {% endfor %}
+                </ul>
+              </div>
+            {% endif %}
+          </div>
       </td>
     </tr>
     {% endfor %}

--- a/csunplugged/topics/models.py
+++ b/csunplugged/topics/models.py
@@ -230,6 +230,9 @@ class ProgrammingChallenge(TranslatableModel):
         }
         return reverse("topics:programming_challenge", kwargs=kwargs)
 
+    def get_learning_outcomes(self):
+        return self.learning_outcomes(manager="translated_objects").order_by("text")
+
     def ordered_implementations(self):
         """Return an ordered QuerySet of implementations.
 

--- a/csunplugged/topics/models.py
+++ b/csunplugged/topics/models.py
@@ -231,6 +231,11 @@ class ProgrammingChallenge(TranslatableModel):
         return reverse("topics:programming_challenge", kwargs=kwargs)
 
     def get_learning_outcomes(self):
+        """Return an ordered QuerySet of translated learning outcomes.
+
+        Returns:
+            Ordered QuerySet.
+        """
         return self.learning_outcomes(manager="translated_objects").order_by("text")
 
     def ordered_implementations(self):


### PR DESCRIPTION
## Proposed changes

Adding learning outcome and solution content to a collapsible area by row in the topics programming challenges table. This has only been implemented in the educator's area, not the student's area. 

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [ ] I have read the contribution guidelines.
- [ ] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [X] The pull request is requesting a merge into the `develop` branch.
- [ ] I have added necessary documentation (if appropriate).
- [ ] If I've added/modified/deleted a third-party system, I've updated the relevant license files.

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
Feel free to add any images that might be helpful to understand the initial problem/solution.
