### PR TITLE
Add sessions to save code attempts for plugging it in

### DIFF
--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -229,7 +229,7 @@ TEMPLATES = [
                 "render_html_field": "config.templatetags.render_html_field",
                 "translate_url": "config.templatetags.translate_url",
                 "query_replace": "config.templatetags.query_replace",
-                'custom_tags':'config.templatetags.custom_tags'
+                'custom_tags': 'config.templatetags.custom_tags'
             },
         },
     },

--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -229,6 +229,7 @@ TEMPLATES = [
                 "render_html_field": "config.templatetags.render_html_field",
                 "translate_url": "config.templatetags.translate_url",
                 "query_replace": "config.templatetags.query_replace",
+                'custom_tags':'config.templatetags.custom_tags'
             },
         },
     },

--- a/csunplugged/config/templatetags/custom_tags.py
+++ b/csunplugged/config/templatetags/custom_tags.py
@@ -1,0 +1,5 @@
+from django.template.defaulttags import register
+
+@register.filter
+def get_item(dictionary, key):
+    return dictionary.get(key)

--- a/csunplugged/config/templatetags/custom_tags.py
+++ b/csunplugged/config/templatetags/custom_tags.py
@@ -1,5 +1,9 @@
+"""Module for the custom dictionary look up template tag."""
+
 from django.template.defaulttags import register
+
 
 @register.filter
 def get_item(dictionary, key):
+    """Return the value in a dictionary given a key."""
     return dictionary.get(key)

--- a/csunplugged/plugging_it_in/urls.py
+++ b/csunplugged/plugging_it_in/urls.py
@@ -32,4 +32,9 @@ urlpatterns = [
         views.JobeProxyView.as_view(),
         name="jobe_proxy"
     ),
+    url(
+        r"^save_attempt$",
+        views.SaveAttemptView.as_view(),
+        name="save_attempt"
+    ),
 ]

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -193,6 +193,9 @@ class SaveAttemptView(View):
         body = json.loads(body_unicode)
 
         request.session['saved_attempts'] = request.session.get('saved_attempts', {})
-        request.session['saved_attempts'][body["challenge"]] = body["attempt"]
+        request.session['saved_attempts'][body["challenge"]] = {
+            "status": body["status"],
+            "code": body["attempt"]
+        }
 
         return HttpResponse("Saved the attempt.")

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -193,9 +193,13 @@ class SaveAttemptView(View):
         body = json.loads(body_unicode)
 
         request.session['saved_attempts'] = request.session.get('saved_attempts', {})
-        request.session['saved_attempts'][body["challenge"]] = {
-            "status": body["status"],
-            "code": body["attempt"]
-        }
 
-        return HttpResponse("Saved the attempt.")
+        # To stop a "passed" or "failed" status being overridden by "started"
+        if not (body["status"] == "started" and request.session.get('saved_attempts', {}).get(body["challenge"], "") in {'passed', 'failed'}) and body["attempt"] != "":
+            request.session['saved_attempts'][body["challenge"]] = {
+                "status": body["status"],
+                "code": body["attempt"]
+            }
+            return HttpResponse("Saved the attempt.")
+        else:
+            return HttpResponse("Response does not need to be saved.")

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -195,7 +195,9 @@ class SaveAttemptView(View):
         request.session['saved_attempts'] = request.session.get('saved_attempts', {})
 
         # To stop a "passed" or "failed" status being overridden by "started"
-        if not (body["status"] == "started" and request.session.get('saved_attempts', {}).get(body["challenge"], "") in {'passed', 'failed'}) and body["attempt"] != "":
+        if (not (body["status"] == "started"
+                 and request.session.get('saved_attempts', {}).get(body["challenge"], "") in {'passed', 'failed'})
+                and body["attempt"] != ""):
             request.session['saved_attempts'][body["challenge"]] = {
                 "status": body["status"],
                 "code": body["attempt"]

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -154,6 +154,8 @@ class ProgrammingChallengeView(generic.DetailView):
         context["test_cases_json"] = json.dumps(list(self.object.related_test_cases().values()))
         context["test_cases"] = self.object.related_test_cases().values()
         context["jobe_proxy_url"] = reverse('plugging_it_in:jobe_proxy')
+        context["saved_attempts"] = self.request.session.get('saved_attempts', {})
+
         return context
 
 
@@ -180,3 +182,17 @@ class JobeProxyView(View):
         response = requests.post(settings.JOBE_SERVER_URL + "/jobe/index.php/restapi/runs/",
                                  data=body, headers=headers)
         return HttpResponse(response.text)
+
+
+class SaveAttemptView(View):
+    """View to save the users challenge attempt."""
+
+    def post(self, request):
+        """Save the users attempt to a Django session."""
+        body_unicode = request.body.decode('utf-8')
+        body = json.loads(body_unicode)
+
+        request.session['saved_attempts'] = request.session.get('saved_attempts', {})
+        request.session['saved_attempts'][body["challenge"]] = body["attempt"]
+
+        return HttpResponse("Saved the attempt.")

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -196,7 +196,8 @@ class SaveAttemptView(View):
 
         # To stop a "passed" or "failed" status being overridden by "started"
         if (not (body["status"] == "started"
-                 and request.session.get('saved_attempts', {}).get(body["challenge"], {}).get("status", "") in {'passed', 'failed'})
+                 and request.session.get('saved_attempts', {}).get(body["challenge"], {}).get("status", "")
+                 in {'passed', 'failed'})
                 and body["attempt"] != ""):
             request.session['saved_attempts'][body["challenge"]] = {
                 "status": body["status"],

--- a/csunplugged/plugging_it_in/views.py
+++ b/csunplugged/plugging_it_in/views.py
@@ -196,7 +196,7 @@ class SaveAttemptView(View):
 
         # To stop a "passed" or "failed" status being overridden by "started"
         if (not (body["status"] == "started"
-                 and request.session.get('saved_attempts', {}).get(body["challenge"], "") in {'passed', 'failed'})
+                 and request.session.get('saved_attempts', {}).get(body["challenge"], {}).get("status", "") in {'passed', 'failed'})
                 and body["attempt"] != ""):
             request.session['saved_attempts'][body["challenge"]] = {
                 "status": body["status"],

--- a/csunplugged/static/js/editor-options-menu.js
+++ b/csunplugged/static/js/editor-options-menu.js
@@ -74,6 +74,14 @@ function setupLessonNav() {
   // Add testing examples info to the requirements block (temporary)
   const static_requirement_info = "Your program should display the outputs in the table (shown on the right) for the given inputs provided.";
   $("#requirement + p").append(`</br></br> <p>${static_requirement_info}</p>`);
+  
+  // Hides the next/prev challenge buttons if there is no challenge available in that direction.
+  const index = getCurrentIndex();
+  if (index === programming_exercises.length-1) {
+    $("#next_challenge_button").find('button').hide()
+  } else if (index === 0) {
+    $("#prev_challenge_button").find('button').hide()
+  }
 }
 
 exports.setupLessonNav = setupLessonNav;

--- a/csunplugged/static/js/editor-options-menu.js
+++ b/csunplugged/static/js/editor-options-menu.js
@@ -19,35 +19,40 @@ function closeNav() {
   document.getElementById("sidebar_overlay").style.opacity = "0";
 }
 
-// Setting up event listener for opening the navigation bar.
-$("#lessons_nav_toggle").click(openNav);
-
-// Setting up event listener for closing the navigation drawer.
-$("#sidebar_overlay").click(closeNav);
-$("#close_nav_button").click(closeNav);
+/**
+ * Gets the index of the current challenge.
+ */
+function getCurrentIndex() {
+  const isCurrentChallengeIndex = (element) => element.slug == current_challenge_slug;
+  return programming_exercises.findIndex(isCurrentChallengeIndex);
+}
 
 /**
- * Sets the link to the next challenge if it is not the last challenge.
- * @param {Number} index The index of the current challenge
+ * Gets the link to the next challenge if it is not the last challenge.
  */
-function setNextChallenge(index) {
+function getNextChallengeURL() {
+  const index = getCurrentIndex();
+
   if (index !== programming_exercises.length-1) {
     const nextLesson = programming_exercises[index+1];
-    const nextLessonUrl = lesson_url + nextLesson.slug;
-    $("#next_challenge_button").attr("href", nextLessonUrl);
+    return nextLessonUrl = lesson_url + nextLesson.slug;
   }
+
+  return '#'
 }
 
 /**
  * Sets the link to the previous challenge if it is not the first challenge.
- * @param {Number} index The index of the current challenge
  */
-function setPreviousChallenge(index) {
+function getPreviousChallengeURL() {
+  const index = getCurrentIndex()
+
   if (index !== 0) {
     const prevLesson = programming_exercises[index-1];
-    const prevLessonUrl = lesson_url + prevLesson.slug;
-    $("#prev_challenge_button").attr("href", prevLessonUrl);
+    return prevLessonUrl = lesson_url + prevLesson.slug;
   }
+
+  return "#"
 }
 
 /**
@@ -55,18 +60,22 @@ function setPreviousChallenge(index) {
  * Also sets the text to show lesson progression.
  */
 function setupLessonNav() {
-  const isCurrentChallengeIndex = (element) => element.slug == current_challenge_slug;
-  currentChallengeIndex = programming_exercises.findIndex(isCurrentChallengeIndex);
+  // Setting up event listener for opening the navigation bar.
+  $("#lessons_nav_toggle").click(openNav);
 
-  const progressionText = `Question <strong>${currentChallengeIndex+1}</strong> of <strong>${programming_exercises.length}</strong>`;
+  // Setting up event listener for closing the navigation drawer.
+  $("#sidebar_overlay").click(closeNav);
+  $("#close_nav_button").click(closeNav);
+
+  // Sets the question progression text.
+  const progressionText = `Question <strong>${getCurrentIndex()+1}</strong> of <strong>${programming_exercises.length}</strong>`;
   document.getElementById("challenge_progression_text").innerHTML = progressionText;
-  setPreviousChallenge(currentChallengeIndex)
-  setNextChallenge(currentChallengeIndex)
+
+  // Add testing examples info to the requirements block (temporary)
+  const static_requirement_info = "Your program should display the outputs in the table (shown on the right) for the given inputs provided.";
+  $("#requirement + p").append(`</br></br> <p>${static_requirement_info}</p>`);
 }
 
-// Apply the navigation setup
-setupLessonNav()
-
-// Add testing examples info to the requirements block (temporary)
-const static_requirement_info = "Your program should display the outputs in the table (shown on the right) for the given inputs provided.";
-$("#requirement + p").append(`</br></br> <p>${static_requirement_info}</p>`);
+exports.setupLessonNav = setupLessonNav;
+exports.getPreviousChallengeURL = getPreviousChallengeURL;
+exports.getNextChallengeURL = getNextChallengeURL;

--- a/csunplugged/static/js/editor-options-menu.js
+++ b/csunplugged/static/js/editor-options-menu.js
@@ -11,7 +11,7 @@ function openNav() {
 }
 
 /**
- * Closes the challenge naviation drawer.
+ * Closes the challenge navigation drawer.
  */
 function closeNav() {
   document.getElementById("my_sidenav").style.width = "0";
@@ -20,15 +20,11 @@ function closeNav() {
 }
 
 // Setting up event listener for opening the navigation bar.
-let lessonsNavToggle = document.getElementById("lessons_nav_toggle");
-lessonsNavToggle.addEventListener("click", openNav);
+$("#lessons_nav_toggle").click(openNav);
 
 // Setting up event listener for closing the navigation drawer.
-let closeLessonsNav = document.getElementById("sidebar_overlay");
-closeLessonsNav.addEventListener("click", closeNav);
-
-let closeLessonsNavButton = document.getElementById("close_nav_button");
-closeLessonsNavButton.addEventListener("click", closeNav);
+$("#sidebar_overlay").click(closeNav);
+$("#close_nav_button").click(closeNav);
 
 /**
  * Sets the link to the next challenge if it is not the last challenge.

--- a/csunplugged/static/js/jobe-editor.js
+++ b/csunplugged/static/js/jobe-editor.js
@@ -156,3 +156,8 @@ $("#editor_run_button").click(sendCodeToJobe);
 
 // Setting up event listener for the download button.
 $("#download_button").click(downloadCode);
+
+// Save code when the user navigates using the next or prev buttons or opening nav
+$("#prev_challenge_button").on("click", () => save_code());
+$("#next_challenge_button").on("click", () => save_code());
+$("#lessons_nav_toggle").on("click", () => save_code());

--- a/csunplugged/static/js/jobe-editor.js
+++ b/csunplugged/static/js/jobe-editor.js
@@ -1,6 +1,7 @@
 // Scripts used to manage the UI functionality for the programming challenge editor screen.
 
-const code_tester = require("./test-code.js");
+const codeTester = require("./test-code.js");
+const editorUtils = require("./editor-options-menu.js")
 
 var CodeMirror = require("codemirror");
 require("codemirror/mode/python/python.js");
@@ -43,7 +44,7 @@ function sendCodeToJobe() {
   $(".code_running_spinner").css("display", "inline-block");
 
   // Run the test_cases
-  code_tester.run_all_testcases(code, test_cases).then(result => {
+  codeTester.run_all_testcases(code, test_cases).then(result => {
     updateResultsTable(result);
 
     // Saving the users code
@@ -83,7 +84,7 @@ async function save_code(status="started") {
   }
 
   // Saves the code in the django session
-  fetch(save_attempt_url, {
+  let response = await fetch(save_attempt_url, {
     method: "POST",
     headers: {
       "Content-type": "application/json; charset=utf-8",
@@ -92,6 +93,8 @@ async function save_code(status="started") {
     },
     body: JSON.stringify(data)
   });
+
+  return response;
 }
 
 /**
@@ -157,7 +160,11 @@ $("#editor_run_button").click(sendCodeToJobe);
 // Setting up event listener for the download button.
 $("#download_button").click(downloadCode);
 
+// Apply the navigation setup
+editorUtils.setupLessonNav()
+
 // Save code when the user navigates using the next or prev buttons or opening nav
-$("#prev_challenge_button").on("click", () => save_code());
-$("#next_challenge_button").on("click", () => save_code());
+// Manually navigating to the next page to ensure code is saved first before the page reloads.
+$("#prev_challenge_button").on("click", () => save_code().then(() => window.location.href = editorUtils.getPreviousChallengeURL()));
+$("#next_challenge_button").on("click", () => save_code().then(() => window.location.href = editorUtils.getNextChallengeURL()));
 $("#lessons_nav_toggle").on("click", () => save_code());

--- a/csunplugged/static/scss/programming-editor.scss
+++ b/csunplugged/static/scss/programming-editor.scss
@@ -371,20 +371,3 @@ body {
   padding: 0px 5px !important;
   margin: 0px;
 }
-
-.status-badge-correct {
-  border-color: #279f2d;
-  background-color: #279f2d;
-  color: white;
-}
-
-.status-badge-incorrect {
-  border-color: #cc0423;
-  background-color: #cc0423;
-  color: white;
-}
-
-.status-badge-started {
-  background-color: #ffc107;
-  border-color: #ffc107;
-}

--- a/csunplugged/static/scss/programming-editor.scss
+++ b/csunplugged/static/scss/programming-editor.scss
@@ -351,3 +351,40 @@ body {
   overflow-x: hidden;
   transition: opacity 0.5s;
 }
+
+.nav-row-info {
+  padding: 0px;
+  padding-left: 30px;
+
+  p {
+    margin-bottom: 0px;
+    padding-left: 0px;
+  }
+}
+
+// Status badges
+.status-badge {
+  border: 1px solid #343a40;
+  color: #343a40;
+  border-radius: 5px; 
+  font-size: 10px;
+  padding: 0px 5px !important;
+  margin: 0px;
+}
+
+.status-badge-correct {
+  border-color: #279f2d;
+  background-color: #279f2d;
+  color: white;
+}
+
+.status-badge-incorrect {
+  border-color: #cc0423;
+  background-color: #cc0423;
+  color: white;
+}
+
+.status-badge-started {
+  background-color: #ffc107;
+  border-color: #ffc107;
+}

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -49,6 +49,8 @@
               badge-danger
             {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "passed" %}
               badge-success
+            {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "started" %}
+              badge-warning
             {% endif %}
           {% else %}
               badge-secondary

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -3,6 +3,7 @@
 {% load i18n %}
 {% load static %}
 {% load render_html_field %}
+{% load custom_tags %}
 {% load django_bootstrap_breadcrumbs %}
 
 {% block title %}
@@ -42,7 +43,16 @@
         {% for programming_challenge_item in programming_challenges %}
         <a href="{% url 'plugging_it_in:programming_challenge' topic.slug lesson.slug programming_challenge_item.slug %}">
          <li class="{% if programming_challenge.slug == programming_challenge_item.slug %}current-exercise{% endif %}">
-          <span class="badge badge-primary">
+          <span class="badge 
+          {% if programming_challenge_item.slug in saved_attempts %}
+            {% if saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "failed" %}
+              badge-danger
+            {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "passed" %}
+              badge-success
+            {% endif %}
+          {% else %}
+              badge-secondary
+          {% endif %}">
             <h5>{{ programming_challenge_item.challenge_set_number }}.{{ programming_challenge_item.challenge_number }}</h5>
           </span> 
           {{ programming_challenge_item.name }}

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -188,5 +188,4 @@
   </script>
 
   <script src="{% static 'js/jobe-editor.js' %}"></script>
-  <script src="{% static 'js/editor-options-menu.js' %}"></script>
 {% endblock scripts %}

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -42,22 +42,31 @@
     <ol class='challenges-list'>
         {% for programming_challenge_item in programming_challenges %}
         <a href="{% url 'plugging_it_in:programming_challenge' topic.slug lesson.slug programming_challenge_item.slug %}">
-         <li class="{% if programming_challenge.slug == programming_challenge_item.slug %}current-exercise{% endif %}">
-          <span class="badge 
-          {% if programming_challenge_item.slug in saved_attempts %}
-            {% if saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "failed" %}
-              badge-danger
-            {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "passed" %}
-              badge-success
-            {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "started" %}
-              badge-warning
-            {% endif %}
-          {% else %}
-              badge-secondary
-          {% endif %}">
-            <h5>{{ programming_challenge_item.challenge_set_number }}.{{ programming_challenge_item.challenge_number }}</h5>
-          </span> 
-          {{ programming_challenge_item.name }}
+         <li class="{% if programming_challenge.slug == programming_challenge_item.slug %}current-exercise{% endif %} row">
+            <div class='row'>
+              <div class='nav-row-info col-10 d-flex'>
+                <div class="d-flex align-items-center"> 
+                  <span class="badge badge-primary">
+                    <h5>{{ programming_challenge_item.challenge_set_number }}.{{ programming_challenge_item.challenge_number }}</h5>
+                  </span> 
+                </div>
+                <p>{{ programming_challenge_item.name }}</p>
+              </div>
+
+              <div class='col-2 d-flex align-items-center justify-content-center'>
+              {% if programming_challenge_item.slug in saved_attempts %}
+                {% if saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "failed" %}
+                  <p class="status-badge status-badge-incorrect">Incorrect</p> 
+                {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "passed" %}
+                  <p class="status-badge status-badge-correct">Correct</p> 
+                {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "started" %}
+                  <p class="status-badge status-badge-started">Started</p> 
+                {% endif %}
+              {% else %}
+                <p class="status-badge">Not started</p> 
+              {% endif %}
+              </div>
+            </div>
           </li>
         </a>
         {% endfor %}

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -162,6 +162,8 @@
     let lesson_url = "{% url 'plugging_it_in:lesson' topic.slug lesson.slug %}";
     let csrf_token = '{{ csrf_token }}';
     let jobe_proxy_url = '{{ jobe_proxy_url }}';
+    let save_attempt_url = "{% url 'plugging_it_in:save_attempt' %}"
+    let saved_attempts = {{ saved_attempts|safe }}
   </script>
 
   <script src="{% static 'js/jobe-editor.js' %}"></script>

--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -56,14 +56,14 @@
               <div class='col-2 d-flex align-items-center justify-content-center'>
               {% if programming_challenge_item.slug in saved_attempts %}
                 {% if saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "failed" %}
-                  <p class="status-badge status-badge-incorrect">Incorrect</p> 
+                  <p class="status-badge bg-danger border-danger text-white">{% trans "Incorrect" %}</p> 
                 {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "passed" %}
-                  <p class="status-badge status-badge-correct">Correct</p> 
+                  <p class="status-badge bg-success border-success text-white">{% trans "Correct" %}</p> 
                 {% elif saved_attempts|get_item:programming_challenge_item.slug|get_item:"status" == "started" %}
-                  <p class="status-badge status-badge-started">Started</p> 
+                  <p class="status-badge border-warning bg-warning">{% trans "Started" %}</p> 
                 {% endif %}
               {% else %}
-                <p class="status-badge">Not started</p> 
+                <p class="status-badge">{% trans "Not started" %}</p> 
               {% endif %}
               </div>
             </div>

--- a/csunplugged/tests/general/templatetags/test_custom_tags.py
+++ b/csunplugged/tests/general/templatetags/test_custom_tags.py
@@ -1,0 +1,41 @@
+from django import template
+from django.test import override_settings
+
+from tests.BaseTest import BaseTest
+
+AVAILABLE_LANGUAGES_EN = (
+    ("en", "English"),
+)
+
+
+class CustomDictTagTest(BaseTest):
+
+    def render_template(self, string, context):
+        context = template.Context(context)
+        return template.Template(string).render(context)
+
+    @override_settings(LANGUAGES=AVAILABLE_LANGUAGES_EN)
+    def test_get_dict_value(self):
+        context = {
+            "a_dictionary": {"test_key": "test_value"}
+        }
+        rendered = self.render_template("{% load custom_tags %}"
+                                        "{% if a_dictionary|get_item:'test_key' == 'test_value' %}Hello{% endif %}",
+                                        context)
+        self.assertEqual(
+            "Hello",
+            rendered
+        )
+
+    @override_settings(LANGUAGES=AVAILABLE_LANGUAGES_EN)
+    def test_get_nonexistant_dict_value(self):
+        context = {
+            "a_dictionary": {"test_key": "test_value"}
+        }
+        rendered = self.render_template("{% load custom_tags %}"
+                                        "{% if a_dictionary|get_item:'bad_key' == 'test_value' %}Hello{% endif %}",
+                                        context)
+        self.assertEqual(
+            "",
+            rendered
+        )


### PR DESCRIPTION
## Proposed changes

Builds off https://github.com/uccser/cs-unplugged/pull/1400

Adds in django sessions to save a users code attempt as well as their status on the question i.e. passed, failed, started or not started.The saved statuses of each question are displayed beside the question in the navigation drawer. The saved code attempts are loaded into the editor automatically on page load if they exist.

Passed/Failed code attempts will occur once the user clicks the 'Check' button and their code is evaluated. The status will be 'Started' if the user enters in a code attempt and either opens up the navigation or clicks the Next/Previous Challenge buttons. Passed/Failed attempts cannot be overwritten by a 'Started' status. By default, each question will have a 'Not Started' status.

### Checklist

*Change the space in the box to an `x` for those you have completed.
You can also fill these out after creating the pull request.
If you're unsure about any of them, don't hesitate to ask.
We're here to help!
This is simply a reminder of what we are going to look for before merging your change.*

- [ ] I have read the contribution guidelines.
- [ ] I have linked any relevant existing issues/suggestions in the description above (include `#???` in your description to reference an issue, where `???` is the issue number).
- [X] The pull request is requesting a merge into the `develop` branch.
- [ ] I have added necessary documentation (if appropriate).
- [ ] If I've added/modified/deleted a third-party system, I've updated the relevant license files.

### Further comments

If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc.
Feel free to add any images that might be helpful to understand the initial problem/solution.
