### PR TITLE
Improve consistency of blues in the PII colour scheme

### DIFF
--- a/csunplugged/static/scss/plugging-it-in-base.scss
+++ b/csunplugged/static/scss/plugging-it-in-base.scss
@@ -1,0 +1,19 @@
+@import "core-variables";
+
+#page-footer {
+    background-color: $plugging-it-in-colour;
+}
+
+.pii-navigation {
+    color: $plugging-it-in-colour;
+    border-color: $plugging-it-in-colour;
+    
+    &:hover {
+        color: white;
+        background-color: $plugging-it-in-colour;
+    }
+    
+    &:focus, &:active, &.active {
+        box-shadow: 0 0 0 .25rem #3044b33f; // This should be $plugging-it-in-colour at 25% opacity
+    }
+}

--- a/csunplugged/static/scss/plugging-it-in-footer.scss
+++ b/csunplugged/static/scss/plugging-it-in-footer.scss
@@ -1,5 +1,0 @@
-@import "core-variables";
-
-#page-footer {
-    background-color: $plugging-it-in-colour;
-}

--- a/csunplugged/static/scss/programming-editor.scss
+++ b/csunplugged/static/scss/programming-editor.scss
@@ -195,7 +195,7 @@ body {
 
     .code_running_spinner {
       display: none;
-      color: #5a9fffff;
+      color: $student-colour-light;
       margin-right: 0.625rem;
     }
 
@@ -205,8 +205,8 @@ body {
     
       .editor_button {
         border: none;
-        background-color: #5a9fffff;
-        border: 2px solid #5a9fffff;
+        background-color: $student-colour-light;
+        border: 2px solid $student-colour-light;
         color: white;
         height: 80%;
         padding: 0px 20px;
@@ -224,8 +224,8 @@ body {
       }
 
       #download_button {
-        border: 2px solid #5a9fffff;
-        color: #5a9fffff; 
+        border: 2px solid $student-colour-light;
+        color: $student-colour-light; 
         background-color: transparent;
       }
 
@@ -314,7 +314,7 @@ body {
   hr {
     height: 3px;
     margin-top: 0px;
-    background: $student-colour-light;
+    background: $student-colour;
   }
 
   .challenges-heading {
@@ -367,6 +367,7 @@ body {
   font-size: 36px;
   margin-left: 50px;
   z-index: 1004;
+  color: $student-colour
 }
 
 
@@ -411,11 +412,12 @@ body {
   color: $student-colour-light;
   border-color: $student-colour-light;
   border-radius: 20px;
-}
-
-#introjs-walkthrough:hover {
-  background-color: $student-colour-light;
-  color: white;
+  &:hover {
+    cursor: pointer;
+    background-color: #1b7bffff;
+    border-color: #1b7bffff;
+    color: white;
+  }
 }
 
 .introjs-fixParent{

--- a/csunplugged/templates/base-plugging-it-in.html
+++ b/csunplugged/templates/base-plugging-it-in.html
@@ -16,7 +16,7 @@
 {% endblock complete_breadcrumbs %}
 
 {% block css %}
-  <link rel="stylesheet" href="{% static 'css/plugging-it-in-footer.css' %}" >
+  <link rel="stylesheet" href="{% static 'css/plugging-it-in-base.css' %}" >
 {% endblock css %}
 
 {% block navbar %}

--- a/csunplugged/templates/plugging_it_in/about.html
+++ b/csunplugged/templates/plugging_it_in/about.html
@@ -51,7 +51,7 @@
     </p>
 
     <p>
-        <a href="{% url 'plugging_it_in:index' %}" class="btn btn-outline-primary">
+        <a href="{% url 'plugging_it_in:index' %}" class="btn pii-navigation">
             {% trans "Go back to home" %}
         </a>
     </p>

--- a/csunplugged/templates/plugging_it_in/index.html
+++ b/csunplugged/templates/plugging_it_in/index.html
@@ -31,7 +31,7 @@
                         {% endblocktrans %}
                         <p class="mb-0">
                             {% with language='en' %}
-                            <a class="btn btn-outline-primary" href="{% translate_url language %}">
+                            <a class="btn pii-navigation" href="{% translate_url language %}">
                                 English
                             </a>
                             {% endwith %}
@@ -56,7 +56,7 @@
                     There are programming challenges at a variety of levels, so choose a difficulty level that’s appropriate for you.
                     {% endblocktrans %}
                 </p>
-                <a href="{% url 'plugging_it_in:about' %}" class="btn btn-outline-primary mb-4">
+                <a href="{% url 'plugging_it_in:about' %}" class="btn pii-navigation mb-4">
                     {% trans "More information for educators" %}
                 </a>
             </div>


### PR DESCRIPTION
Reduces the number of different shades of blues used in the Plugging It In area of the website:
- Navigation buttons, like `More information for educators` are now the main theme colour
- The `X` and horizontal line in the challenge hamburger menu is now the main theme colour
- The `How does this page work?` button on the challenge page now uses the same hover colour as the buttons `Check` and `Download`

Note that I renamed the file `plugging-it-in-footer.scss`, as somewhere to put the new `pii-navigation` class. I'm happy to rename or relocate the class if there's a better place for it

I also replaced several re-definitions of preset colours with their variable names