### PR TITLE
Use django docs method for handling the csrf token for a PII challenge

### DIFF
--- a/csunplugged/templates/plugging_it_in/programming-challenge.html
+++ b/csunplugged/templates/plugging_it_in/programming-challenge.html
@@ -180,12 +180,13 @@
 {% endblock body_container %}
 
 {% block scripts %}
+  {% csrf_token %}
   <script type="text/javascript">
     let current_challenge_slug = '{{ programming_challenge.slug }}';
     let test_cases = {{ test_cases_json|safe }};
     let programming_exercises = {{ programming_exercises_json|safe }};
     let lesson_url = "{% url 'plugging_it_in:lesson' topic.slug lesson.slug %}";
-    let csrf_token = '{{ csrf_token }}';
+    let csrf_token = jQuery("[name=csrfmiddlewaretoken]").val();
     let jobe_proxy_url = '{{ jobe_proxy_url }}';
     let save_attempt_url = "{% url 'plugging_it_in:save_attempt' %}"
   </script>


### PR DESCRIPTION
For consistency more than anything. There is no security problem with the existing method.

The method used is used as an [example in the django docs](https://docs.djangoproject.com/en/2.2/ref/csrf/#acquiring-the-token-if-csrf-use-sessions-or-csrf-cookie-httponly-is-true)