### PR TITLE
Hotfix 6.1.2

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,1 @@
+csunplugged/build/img/

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "6.1.1"
+__version__ = "6.1.2"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,17 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
+6.1.2
+==============================================================================
+
+- **Release date:** 8th December 2020
+- **Downloads:** `Source downloads are available on GitHub <https://github.com/uccser/cs-unplugged/releases/>`__
+
+**Changelog:**
+
+- Ignore certain files in Google Cloud.
+
+
 6.1.1
 ==============================================================================
 

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -31,7 +31,7 @@ All notable changes to this project will be documented in this file.
 
 **Changelog:**
 
-- Ignore certain files in Google Cloud.
+- Ignore the csunplugged/build/img folder in Google Cloud.
 
 
 6.1.1


### PR DESCRIPTION
We have reached a resource limit (`build/img` folder has reached 1000 files) in Google Cloud which is preventing deployments.

We do not need this folder to deploy, so we now tell gcloud to ignore the folder in the file `.gcloudignore`.

Docs are [here](https://cloud.google.com/sdk/gcloud/reference/topic/gcloudignore).