### PR TITLE
Hotfix 6.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-app.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy static files to Google Storage Bucket"
       deploy:
@@ -157,7 +157,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-static-files.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Update Google Cloud Platform database"
       deploy:
@@ -165,7 +165,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/update-database.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 1"
       deploy:
@@ -173,7 +173,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-1.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 2"
       deploy:
@@ -181,7 +181,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-2.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 3"
       deploy:
@@ -189,7 +189,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-3.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 4"
       deploy:
@@ -197,7 +197,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-4.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 5"
       deploy:
@@ -205,7 +205,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-5.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 6"
       deploy:
@@ -213,7 +213,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-6.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 7"
       deploy:
@@ -221,7 +221,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-7.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 8"
       deploy:
@@ -229,7 +229,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-8.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 9"
       deploy:
@@ -237,7 +237,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-9.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 10"
       deploy:
@@ -245,7 +245,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-10.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 11"
       deploy:
@@ -253,7 +253,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-11.sh
           skip_cleanup: true
           on:
-            branch: master
+            branch: hotfix-6.1.3
 notifications:
   email: false
   slack:
@@ -265,4 +265,4 @@ stages:
   - name: develop deploy
     if: branch = develop
   - name: production deploy
-    if: branch = master
+    if: branch = hotfix-6.1.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -149,7 +149,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-app.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy static files to Google Storage Bucket"
       deploy:
@@ -157,7 +157,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-static-files.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Update Google Cloud Platform database"
       deploy:
@@ -165,7 +165,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/update-database.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 1"
       deploy:
@@ -173,7 +173,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-1.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 2"
       deploy:
@@ -181,7 +181,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-2.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 3"
       deploy:
@@ -189,7 +189,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-3.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 4"
       deploy:
@@ -197,7 +197,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-4.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 5"
       deploy:
@@ -205,7 +205,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-5.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 6"
       deploy:
@@ -213,7 +213,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-6.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 7"
       deploy:
@@ -221,7 +221,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-7.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 8"
       deploy:
@@ -229,7 +229,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-8.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 9"
       deploy:
@@ -237,7 +237,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-9.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 10"
       deploy:
@@ -245,7 +245,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-10.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
     - script: skip
       name: "Copy resource PDFs to Google Storage Bucket - Part 11"
       deploy:
@@ -253,7 +253,7 @@ jobs:
           script: bash ./infrastructure/prod-deploy/deploy-resources-11.sh
           skip_cleanup: true
           on:
-            branch: hotfix-6.1.3
+            branch: master
 notifications:
   email: false
   slack:
@@ -265,4 +265,4 @@ stages:
   - name: develop deploy
     if: branch = develop
   - name: production deploy
-    if: branch = hotfix-6.1.3
+    if: branch = master

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "6.1.2"
+__version__ = "6.1.3"

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -23,6 +23,19 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
+6.1.3
+==============================================================================
+
+- **Release date:** 8th December 2020
+- **Downloads:** `Source downloads are available on GitHub <https://github.com/uccser/cs-unplugged/releases/>`__
+
+**Changelog:**
+
+- Remove the following folders when deploying to production:
+    - csunplugged/build
+    - csunplugged/temp
+    - csunplugged/staticfiles
+
 6.1.2
 ==============================================================================
 
@@ -32,7 +45,6 @@ All notable changes to this project will be documented in this file.
 **Changelog:**
 
 - Ignore the csunplugged/build/img folder in Google Cloud.
-
 
 6.1.1
 ==============================================================================

--- a/infrastructure/prod-deploy/deploy-app.sh
+++ b/infrastructure/prod-deploy/deploy-app.sh
@@ -34,6 +34,9 @@ cp -r csunplugged/locale/xx_LR csunplugged/locale/yy_RL
 ./csu start
 ./csu update
 
+rm -rf csunplugged/build
+rm -rf csunplugged/staticfiles
+
 # Publish Django system to Google App Engine.
 #
 # This deploys using the 'app-develop.yaml' decrypted earlier that contains

--- a/infrastructure/prod-deploy/deploy-app.sh
+++ b/infrastructure/prod-deploy/deploy-app.sh
@@ -34,8 +34,8 @@ cp -r csunplugged/locale/xx_LR csunplugged/locale/yy_RL
 ./csu start
 ./csu update
 
-rm -rf csunplugged/build
-rm -rf csunplugged/staticfiles
+sudo rm -rf csunplugged/build
+sudo rm -rf csunplugged/staticfiles
 
 # Publish Django system to Google App Engine.
 #

--- a/infrastructure/prod-deploy/deploy-app.sh
+++ b/infrastructure/prod-deploy/deploy-app.sh
@@ -35,6 +35,7 @@ cp -r csunplugged/locale/xx_LR csunplugged/locale/yy_RL
 ./csu update
 
 sudo rm -rf csunplugged/build
+sudo rm -rf csunplugged/temp
 sudo rm -rf csunplugged/staticfiles
 
 # Publish Django system to Google App Engine.


### PR DESCRIPTION
**Changelog:**

- Remove the following folders when deploying to production:
    - csunplugged/build
    - csunplugged/temp
    - csunplugged/staticfiles

When the dev sites are back up we will probably have to add the commands into the develop deploy script too. (If we are still with GC then).