### PR TITLE
Release 7.2.1

### DIFF
--- a/csunplugged/at_home/content/en/kidbots/more-information.md
+++ b/csunplugged/at_home/content/en/kidbots/more-information.md
@@ -1,4 +1,4 @@
 - Often we do this with a third helper, a “tester”, who reads out the instructions to the bot, but in the home version the bot themselves can test the instructions.
-  [Here](https://player.vimeo.com/video/292222421) is a demonstration of this in action.
+  [Here](https://player.vimeo.com/video/292209041) is a demonstration of this in action.
 - [Here’s]('topics:lesson' 'kidbots' 'rescue-mission') a version where the challenge is given as a Rescue Mission.
 - There are online versions that can be used to explore and extend this kind of programming; for example, [Lightbot](https://lightbot.com/), [ScratchJr](https://www.scratchjr.org/) and Bee-Bot for [Android](https://play.google.com/store/apps/details?id=com.tts.beebot&hl=en) and [iOS](https://apps.apple.com/us/app/bee-bot/id500131639).

--- a/csunplugged/at_home/content/en/mind-reading-magic/more-information.md
+++ b/csunplugged/at_home/content/en/mind-reading-magic/more-information.md
@@ -1,5 +1,5 @@
 To see more examples of this in action check out these video links.
 
-- [Demonstration with a small group](https://player.vimeo.com/video/343171153).
+- [Demonstration with a small group](https://player.vimeo.com/video/343170000).
 - The parity trick as a [street show(!)](https://youtu.be/OXz64qCjZ6k)
 - [This site](https://csfieldguide.org.nz/en/interactives/parity/) allows you to practise putting down the extra cards, and you can choose how big the grid is.

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "7.2.0"
+__version__ = "7.2.1"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,7 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
-7.3.0
+7.2.0
 ==============================================================================
 
 **Release date:** 2 November 2022

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,16 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
+7.2.1
+==============================================================================
+
+**Release date:** 3 November 2022
+
+**Changelog:**
+
+- Update embedded 'At home' videos to UCCSER original versions. Previous versions were modified variants.
+- Fix typo of wrong version number in changelog.
+
 7.2.0
 ==============================================================================
 


### PR DESCRIPTION
- Update embedded 'At home' videos to UCCSER original versions. Previous versions were modified variants.
- Fix typo of wrong version number in changelog.