### PR TITLE
Fix flaky test

### DIFF
--- a/csunplugged/tests/topics/loaders/test_lessons_loader.py
+++ b/csunplugged/tests/topics/loaders/test_lessons_loader.py
@@ -804,13 +804,14 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_objects = Lesson.objects.all()
         self.assertQuerysetEqual(
-            list(lesson_objects),
+            lesson_objects,
             [
                 "<Lesson: Lesson 0>",
                 "<Lesson: Lesson 1>",
                 "<Lesson: Lesson 2>",
                 "<Lesson: Lesson 3>",
             ],
+            ordered=False,
         )
 
         config_file = "multiple-lessons.yaml"
@@ -823,10 +824,11 @@ class LessonsLoaderTest(BaseTestWithDB):
 
         lesson_objects = Lesson.objects.all()
         self.assertQuerysetEqual(
-            list(lesson_objects),
+            lesson_objects,
             [
                 "<Lesson: Lesson 1>",
                 "<Lesson: Lesson 2>",
                 "<Lesson: Lesson 3>",
-            ]
+            ],
+            ordered=False,
         )


### PR DESCRIPTION
Because the database doesn't necessarily return entries in the same order every time, this test was flaky as it depended on the order of the entries. It has been updated to do an unordered check instead. This is fine because there is another table in the database that stores the order that the lessons are displayed in the user interface, so we don't lose anything from this change.