### PR TITLE
7.5.0

### DIFF
--- a/.github/workflows/auto-merge-dependency-updates.yaml
+++ b/.github/workflows/auto-merge-dependency-updates.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1.6.0
+        uses: dependabot/fetch-metadata@v2.0.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve

--- a/.github/workflows/auto-merge-dependency-updates.yaml
+++ b/.github/workflows/auto-merge-dependency-updates.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2.0.0
+        uses: dependabot/fetch-metadata@v2.1.0
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Approve

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: true
 
     - name: Download Chinese (simplified) translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download French translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -78,7 +78,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Indonesian translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -96,7 +96,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Italian translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -114,7 +114,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true
@@ -132,7 +132,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Turkish translations
-      uses: crowdin/github-action@v1.19.0
+      uses: crowdin/github-action@v1.20.0
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: true
 
     - name: Download Chinese (simplified) translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download French translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -78,7 +78,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Indonesian translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -96,7 +96,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Italian translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -114,7 +114,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true
@@ -132,7 +132,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Turkish translations
-      uses: crowdin/github-action@v1.20.1
+      uses: crowdin/github-action@v1.20.2
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: true
 
     - name: Download Chinese (simplified) translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download French translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -78,7 +78,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Indonesian translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -96,7 +96,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Italian translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -114,7 +114,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true
@@ -132,7 +132,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Turkish translations
-      uses: crowdin/github-action@v1.20.2
+      uses: crowdin/github-action@v1.20.3
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: true
 
     - name: Download Chinese (simplified) translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download French translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -78,7 +78,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Indonesian translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -96,7 +96,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Italian translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -114,7 +114,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true
@@ -132,7 +132,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Turkish translations
-      uses: crowdin/github-action@v1.20.3
+      uses: crowdin/github-action@v1.20.4
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/crowdin-actions.yaml
+++ b/.github/workflows/crowdin-actions.yaml
@@ -19,12 +19,12 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Upload or update source files to Crowdin
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: true
 
     - name: Download Chinese (simplified) translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -42,7 +42,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download French translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -60,7 +60,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download German translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -78,7 +78,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Indonesian translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -96,7 +96,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Italian translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -114,7 +114,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Te Reo Māori translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true
@@ -132,7 +132,7 @@ jobs:
         config: crowdin.yaml
 
     - name: Download Turkish translations
-      uses: crowdin/github-action@v1.20.0
+      uses: crowdin/github-action@v1.20.1
       with:
         upload_sources: false
         download_translations: true

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -64,10 +64,12 @@ jobs:
       - name: Create coverage file
         run: docker compose -f docker-compose.local.yml run --rm --user="root" django coverage xml -i
       - name: Upload coverage file
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./csunplugged/coverage.xml
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-resources:
     name: Tests - Resources
@@ -80,10 +82,12 @@ jobs:
       - name: Create coverage file
         run: docker compose -f docker-compose.local.yml run --rm --user="root" django coverage xml -i
       - name: Upload coverage file
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./csunplugged/coverage.xml
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-management:
     name: Tests - Management
@@ -96,10 +100,12 @@ jobs:
       - name: Create coverage file
         run: docker compose -f docker-compose.local.yml run --rm --user="root" django coverage xml -i
       - name: Upload coverage file
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./csunplugged/coverage.xml
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   test-style:
     name: Tests - Style

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -406,7 +406,7 @@ jobs:
             type=ref,event=branch,priority=2
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.1.0
+        uses: docker/build-push-action@v5.2.0
         with:
           file: ./infrastructure/production/django/Dockerfile
           context: .

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -117,7 +117,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Python
-        uses: actions/setup-python@v5.0.0
+        uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.x'
       - name: Install dependencies

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -390,7 +390,7 @@ jobs:
           ls artifacts/at-a-distance-files-*/at-a-distance-files.tar.gz | xargs -n1 tar -xz --directory csunplugged/staticfiles/slides --file
 
       - name: Log in to the Container registry
-        uses: docker/login-action@v3.0.0
+        uses: docker/login-action@v3.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/test-and-deploy.yaml
+++ b/.github/workflows/test-and-deploy.yaml
@@ -406,7 +406,7 @@ jobs:
             type=ref,event=branch,priority=2
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5.2.0
+        uses: docker/build-push-action@v5.3.0
         with:
           file: ./infrastructure/production/django/Dockerfile
           context: .

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "7.4.0"
+__version__ = "7.4.1"

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "7.3.0"
+__version__ = "7.4.0"

--- a/csunplugged/config/__init__.py
+++ b/csunplugged/config/__init__.py
@@ -1,3 +1,3 @@
 """Module for Django system configuration."""
 
-__version__ = "7.4.1"
+__version__ = "7.5.0"

--- a/csunplugged/config/settings/base.py
+++ b/csunplugged/config/settings/base.py
@@ -328,10 +328,5 @@ CORS_ALLOWED_ORIGINS = [
     "https://canterbury.ac.nz"
 ]
 
-CSRF_TRUSTED_ORIGINS = [
-    "https://*.localhost",
-    "https://*.canterbury.ac.nz"
-]
-
 # Used by speaker notes for at a distance slides
 X_FRAME_OPTIONS = "SAMEORIGIN"

--- a/csunplugged/config/settings/local.py
+++ b/csunplugged/config/settings/local.py
@@ -99,3 +99,12 @@ TEST_RUNNER = "django.test.runner.DiscoverRunner"
 # Suppress these loggers in local development for less noise in logs
 logging.getLogger('gunicorn.access').handlers = []  # noqa F405
 logging.getLogger('gunicorn.error').handlers = []  # noqa F405
+
+
+# CSRF
+# ------------------------------------------------------------------------------
+CSRF_TRUSTED_ORIGINS = [
+    "https://www.csunplugged.org",
+    "https://cs-unplugged-dev.csse.canterbury.ac.nz",
+    "https://cs-unplugged.localhost",
+]

--- a/csunplugged/config/settings/production.py
+++ b/csunplugged/config/settings/production.py
@@ -71,3 +71,9 @@ DATABASES = {
 # SECURE_SSL_REDIRECT = env.bool("DJANGO_SECURE_SSL_REDIRECT", default=True)  # noqa: F405
 # CSRF_COOKIE_SECURE = True
 # CSRF_COOKIE_HTTPONLY = True
+
+# CSRF
+# ------------------------------------------------------------------------------
+CSRF_TRUSTED_ORIGINS = [
+    "https://www.csunplugged.org",
+]

--- a/csunplugged/config/settings/production.py
+++ b/csunplugged/config/settings/production.py
@@ -76,4 +76,5 @@ DATABASES = {
 # ------------------------------------------------------------------------------
 CSRF_TRUSTED_ORIGINS = [
     "https://www.csunplugged.org",
+    "https://cs-unplugged-dev.csse.canterbury.ac.nz",
 ]

--- a/csunplugged/config/settings/testing.py
+++ b/csunplugged/config/settings/testing.py
@@ -84,7 +84,6 @@ LANGUAGES = (
 # CSRF
 # ------------------------------------------------------------------------------
 CSRF_TRUSTED_ORIGINS = [
-    "https://www.csunplugged.org",
-    "https://cs-unplugged-dev.csse.canterbury.ac.nz",
+    "https://*.canterbury.ac.nz",
     "https://cs-unplugged.localhost",
 ]

--- a/csunplugged/config/settings/testing.py
+++ b/csunplugged/config/settings/testing.py
@@ -80,3 +80,11 @@ LANGUAGES = (
     ("de", "German"),
     ("fr", "French"),
 )
+
+# CSRF
+# ------------------------------------------------------------------------------
+CSRF_TRUSTED_ORIGINS = [
+    "https://www.csunplugged.org",
+    "https://cs-unplugged-dev.csse.canterbury.ac.nz",
+    "https://cs-unplugged.localhost",
+]

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.1.0",
-        "sass": "1.76.0",
+        "sass": "1.77.0",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -34,7 +34,7 @@
         "popper.js": "1.16.1",
         "postcss": "8.4.35",
         "postcss-flexbugs-fixes": "5.0.2",
-        "reveal.js": "5.0.4",
+        "reveal.js": "5.0.5",
         "sass": "1.71.1",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.1.0",
-        "sass": "1.74.1",
+        "sass": "1.75.0",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -5,7 +5,7 @@
     "dependencies": {},
     "devDependencies": {
         "ansi-colors": "4.1.3",
-        "autoprefixer": "10.4.17",
+        "autoprefixer": "10.4.18",
         "bootstrap": "4.6.1",
         "browser-sync": "3.0.2",
         "browserify": "17.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -5,7 +5,7 @@
     "dependencies": {},
     "devDependencies": {
         "ansi-colors": "4.1.3",
-        "autoprefixer": "10.4.18",
+        "autoprefixer": "10.4.19",
         "bootstrap": "4.6.1",
         "browser-sync": "3.0.2",
         "browserify": "17.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.1.1",
+        "cssnano": "6.1.2",
         "blockly": "10.4.3",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.1.0",
-        "sass": "1.75.0",
+        "sass": "1.76.0",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.0.4",
+        "cssnano": "6.0.5",
         "blockly": "10.4.2",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -12,7 +12,7 @@
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
         "cssnano": "6.0.3",
-        "blockly": "10.4.1",
+        "blockly": "10.4.2",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",
         "gulp-concat": "2.6.1",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -32,7 +32,7 @@
         "multiple-select": "1.7.0",
         "pixrem": "5.0.0",
         "popper.js": "1.16.1",
-        "postcss": "8.4.36",
+        "postcss": "8.4.37",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.0.5",
         "sass": "1.72.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.1.2",
+        "cssnano": "7.0.1",
         "blockly": "10.4.3",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.1.0",
-        "sass": "1.77.0",
+        "sass": "1.77.1",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -20,7 +20,7 @@
         "gulp-error-handle": "1.0.1",
         "gulp-filter": "9.0.1",
         "gulp-if": "3.0.0",
-        "gulp-imagemin": "9.0.0",
+        "gulp-imagemin": "9.1.0",
         "gulp-postcss": "10.0.0",
         "gulp-sass": "5.1.0",
         "gulp-sourcemaps": "3.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.0.3",
+        "cssnano": "6.0.4",
         "blockly": "10.4.2",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -32,7 +32,7 @@
         "multiple-select": "1.7.0",
         "pixrem": "5.0.0",
         "popper.js": "1.16.1",
-        "postcss": "8.4.37",
+        "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.0.5",
         "sass": "1.72.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.1.0",
+        "cssnano": "6.1.1",
         "blockly": "10.4.3",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -11,7 +11,7 @@
         "browserify": "17.0.0",
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
-        "cssnano": "6.0.5",
+        "cssnano": "6.1.0",
         "blockly": "10.4.2",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -32,7 +32,7 @@
         "multiple-select": "1.7.0",
         "pixrem": "5.0.0",
         "popper.js": "1.16.1",
-        "postcss": "8.4.35",
+        "postcss": "8.4.36",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.0.5",
         "sass": "1.72.0",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.35",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.0.5",
-        "sass": "1.71.1",
+        "sass": "1.72.0",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.0.5",
-        "sass": "1.72.0",
+        "sass": "1.74.1",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -34,7 +34,7 @@
         "popper.js": "1.16.1",
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
-        "reveal.js": "5.0.5",
+        "reveal.js": "5.1.0",
         "sass": "1.74.1",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -12,7 +12,7 @@
         "child_process": "1.0.2",
         "codemirror": "5.65.6",
         "cssnano": "6.1.0",
-        "blockly": "10.4.2",
+        "blockly": "10.4.3",
         "details-element-polyfill": "2.4.0",
         "fancy-log": "2.0.0",
         "gulp-concat": "2.6.1",

--- a/csunplugged/package.json
+++ b/csunplugged/package.json
@@ -35,7 +35,7 @@
         "postcss": "8.4.38",
         "postcss-flexbugs-fixes": "5.0.2",
         "reveal.js": "5.1.0",
-        "sass": "1.77.1",
+        "sass": "1.77.2",
         "scratchblocks": "3.6.4",
         "vinyl-buffer": "1.0.1",
         "yargs": "17.7.2"

--- a/csunplugged/resources/generators/BinaryCardsResourceGenerator.py
+++ b/csunplugged/resources/generators/BinaryCardsResourceGenerator.py
@@ -57,7 +57,7 @@ class BinaryCardsResourceGenerator(BaseResourceGenerator):
             font_path = "static/fonts/PatrickHand-Regular.ttf"
             font = ImageFont.truetype(font_path, 600)
             BASE_COORD_X = IMAGE_SIZE_X / 2
-            BASE_COORD_Y = image_size_y - 100
+            BASE_COORD_Y = image_size_y - 150
             image_size_y = image_size_y + 300
 
         pages = []
@@ -69,7 +69,8 @@ class BinaryCardsResourceGenerator(BaseResourceGenerator):
                 background.paste(image, mask=image)
                 draw = ImageDraw.Draw(background)
                 text = str(number)
-                text_width, text_height = draw.textsize(text, font=font)
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+                text_width, text_height = right - left, bottom - top
                 coord_x = BASE_COORD_X - (text_width / 2)
                 coord_y = BASE_COORD_Y - (text_height / 2)
                 draw.text(

--- a/csunplugged/resources/generators/BinaryCardsSmallResourceGenerator.py
+++ b/csunplugged/resources/generators/BinaryCardsSmallResourceGenerator.py
@@ -60,10 +60,10 @@ class BinaryCardsSmallResourceGenerator(BaseResourceGenerator):
             font_path = "static/fonts/PatrickHand-Regular.ttf"
             font = ImageFont.truetype(font_path, 200)
             TEXT_COORDS = [
-                (525, 1341),
-                (1589, 1341),
-                (525, 2889),
-                (1589, 2889),
+                (525, 1311),
+                (1589, 1311),
+                (525, 2859),
+                (1589, 2859),
             ]
 
         pages = []
@@ -75,7 +75,8 @@ class BinaryCardsSmallResourceGenerator(BaseResourceGenerator):
                     draw = ImageDraw.Draw(image)
                     for number in range(image_bits - 4, image_bits):
                         text = str(pow(2, number))
-                        text_width, text_height = draw.textsize(text, font=font)
+                        left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+                        text_width, text_height = right - left, bottom - top
                         coord_x = TEXT_COORDS[number % 4][0] - (text_width / 2)
                         coord_y = TEXT_COORDS[number % 4][1] - (text_height / 2)
                         draw.text(

--- a/csunplugged/resources/generators/BinaryWindowsResourceGenerator.py
+++ b/csunplugged/resources/generators/BinaryWindowsResourceGenerator.py
@@ -176,7 +176,7 @@ class BinaryWindowsResourceGenerator(BaseResourceGenerator):
         coord_x_increment = column_width
         coord_x = coord_x_start
         base_image_coord_y = IMAGE_SIZE_Y * 0.2
-        base_text_coord_y = IMAGE_SIZE_Y * 0.4
+        base_text_coord_y = IMAGE_SIZE_Y * 0.38
         dots_value = 1
 
         while coord_x > 0:
@@ -204,7 +204,8 @@ class BinaryWindowsResourceGenerator(BaseResourceGenerator):
 
             if show_bits_value:
                 text = str(dots_value)
-                text_width, text_height = draw.textsize(text, font=SMALL_FONT)
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=SMALL_FONT)
+                text_width, text_height = right - left, bottom - top
                 text_coord_x = coord_x - (text_width / 2)
                 text_coord_y = base_text_coord_y - (text_height / 2)
                 draw.text(
@@ -267,7 +268,8 @@ class BinaryWindowsResourceGenerator(BaseResourceGenerator):
 
         while coord_x < IMAGE_SIZE_X:
             if value_type == "binary":
-                text_width, text_height = draw.textsize(text, font=FONT)
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=FONT)
+                text_width, text_height = right - left, bottom - top
                 text_coord_x = coord_x - (text_width / 2)
                 text_coord_y = base_coord_y - (text_height * .7)
                 draw.text(

--- a/csunplugged/resources/generators/ModuloClockResourceGenerator.py
+++ b/csunplugged/resources/generators/ModuloClockResourceGenerator.py
@@ -56,9 +56,10 @@ class ModuloClockResourceGenerator(BaseResourceGenerator):
             angle = start_angle + (angle_between_numbers * number)
             x_coord = radius * cos(angle) + x_center
             y_coord = radius * sin(angle) + y_center
-            text_width, text_height = draw.textsize(text, font=font)
+            left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+            text_width, text_height = right - left, bottom - top
             text_coord_x = x_coord - (text_width / 2)
-            text_coord_y = y_coord - (text_height / 2)
+            text_coord_y = y_coord - (text_height / 2) - 40
             draw.text(
                 (text_coord_x, text_coord_y),
                 text,

--- a/csunplugged/resources/generators/PixelPainterResourceGenerator.py
+++ b/csunplugged/resources/generators/PixelPainterResourceGenerator.py
@@ -218,7 +218,8 @@ class PixelPainterResourceGenerator(BaseResourceGenerator):
                 )
 
                 # Draw text
-                text_width, text_height = draw.textsize(text, font=self.FONT)
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=self.FONT)
+                text_width, text_height = right - left, bottom - top
                 text_coord_x = (column * self.BOX_SIZE) + (self.BOX_SIZE / 2) - (text_width / 2)
                 text_coord_y = (row * self.BOX_SIZE) + (self.BOX_SIZE / 2) - (text_height / 2)
                 draw.text(

--- a/csunplugged/resources/generators/SearchingCardsResourceGenerator.py
+++ b/csunplugged/resources/generators/SearchingCardsResourceGenerator.py
@@ -7,10 +7,11 @@ from yattag import Doc
 from resources.utils.BaseResourceGenerator import BaseResourceGenerator
 from django.utils.translation import gettext_lazy as _
 from resources.utils.resource_parameters import EnumResourceParameter, BoolResourceParameter
+
 IMAGE_PATH = "static/img/resources/searching-cards/{}-cards-{}.png"
 X_BASE_COORD = 1803
 X_COORD_DECREMENT = 516
-Y_COORD = 240
+Y_COORD = 200
 FONT_PATH = "static/fonts/PatrickHand-Regular.ttf"
 FONT = ImageFont.truetype(FONT_PATH, 200)
 
@@ -94,7 +95,8 @@ class SearchingCardsResourceGenerator(BaseResourceGenerator):
                 coord_x = X_BASE_COORD
                 for number in page_numbers:
                     text = str(number)
-                    text_width, text_height = draw.textsize(text, font=FONT)
+                    left, top, right, bottom = draw.textbbox((0, 0), text, font=FONT)
+                    text_width, text_height = right - left, bottom - top
                     draw.text(
                         (coord_x - (text_width / 2), Y_COORD - (text_height / 2)),
                         text,

--- a/csunplugged/resources/generators/SortingNetworkCardsResourceGenerator.py
+++ b/csunplugged/resources/generators/SortingNetworkCardsResourceGenerator.py
@@ -133,7 +133,7 @@ class SortingNetworkCardsResourceGenerator(BaseResourceGenerator):
                     ratio = min(height_ratio, width_ratio)
                     width *= ratio
                     height *= ratio
-                    image = image.resize((int(width), int(height)), Image.ANTIALIAS)
+                    image = image.resize((int(width), int(height)), Image.LANCZOS)
                 if image_number % 2 == 0:
                     page = card_outlines.copy()
                     draw = ImageDraw.Draw(page)
@@ -169,9 +169,10 @@ class SortingNetworkCardsResourceGenerator(BaseResourceGenerator):
                 else:
                     (x, y) = card_centers[1]
 
-                text_width, text_height = draw.textsize(text_string, font=font)
+                left, top, right, bottom = draw.textbbox((0, 0), text_string, font=font)
+                text_width, text_height = right - left, bottom - top
                 coord_x = x - (text_width / 2)
-                coord_y = y - (text_height / 1.5)
+                coord_y = y - text_height
                 draw.text(
                     (coord_x, coord_y),
                     text_string,

--- a/csunplugged/resources/generators/SortingNetworkResourceGenerator.py
+++ b/csunplugged/resources/generators/SortingNetworkResourceGenerator.py
@@ -51,9 +51,10 @@ class SortingNetworkResourceGenerator(BaseResourceGenerator):
             coord_x_increment = 204
             for number in numbers:
                 text = str(number)
-                text_width, text_height = draw.textsize(text, font=font)
+                left, top, right, bottom = draw.textbbox((0, 0), text, font=font)
+                text_width, text_height = right - left, bottom - top
                 coord_x = base_coord_x - (text_width / 2)
-                coord_y = base_coord_y - (text_height / 2)
+                coord_y = base_coord_y - (text_height / 1.2)
                 draw.text(
                     (coord_x, coord_y),
                     text,

--- a/csunplugged/resources/utils/resize_encode_resource_images.py
+++ b/csunplugged/resources/utils/resize_encode_resource_images.py
@@ -55,7 +55,7 @@ def resize_encode_resource_image(image, max_pixel_height):
         ratio = max_pixel_height / height
         width *= ratio
         height *= ratio
-        image = image.resize((int(width), int(height)), Image.ANTIALIAS)
+        image = image.resize((int(width), int(height)), Image.LANCZOS)
     # Convert from Image object to base64 string
     image_buffer = BytesIO()
     image.save(image_buffer, format="PNG")

--- a/csunplugged/tests/utils/text_box_drawer/test_text_box_drawer.py
+++ b/csunplugged/tests/utils/text_box_drawer/test_text_box_drawer.py
@@ -152,7 +152,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 50
         font = ImageFont.truetype(font_path, font_size)
         text = "This is a string"
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width * 2,
@@ -173,7 +174,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 50
         font = ImageFont.truetype(font_path, font_size)
         text = "This is a string"
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width * 0.8,  # Make box slightly narrower than text, to force 2 lines
@@ -193,7 +195,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 50
         font = ImageFont.truetype(font_path, font_size)
         text = "This is a string"
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width * 0.8,  # Make box slightly narrower than text, to force 2 lines
@@ -213,7 +216,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 10
         text = "This is a string"
         font = ImageFont.truetype(font_path, font_size * 2)
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width,
@@ -229,7 +233,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 10
         text = "This is a string"
         font = ImageFont.truetype(font_path, font_size)
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width - 1,  # Force one decrease loop
@@ -245,7 +250,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 100
         text = "This is a string"
         font = ImageFont.truetype(font_path, font_size)
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width * 0.5,  # Force many decrease loops
@@ -261,7 +267,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 10
         text = ""
         font = ImageFont.truetype(font_path, font_size)
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width,
@@ -280,7 +287,8 @@ class TextBoxDrawerTest(SimpleTestCase):
         font_size = 10
         text = "word"
         font = ImageFont.truetype(font_path, font_size)
-        text_width, text_height = font.getsize(text)
+        left, top, right, bottom = font.getbbox(text)
+        text_width, text_height = right - left, bottom - top
         new_font_size, lines, new_text_width, new_text_height = TextBoxDrawer.fit_text(
             text,
             text_width,

--- a/csunplugged/utils/TextBoxDrawer.py
+++ b/csunplugged/utils/TextBoxDrawer.py
@@ -229,7 +229,9 @@ class TextBoxDrawer(object):
             font: PIL.ImageFont object
             text: (str) text to get width of
         """
-        return font.getsize(text)[0]
+        left, top, right, bottom = font.getbbox(text)
+        width = right - left
+        return width
 
     @staticmethod
     def get_font(font_path, font_size):
@@ -363,12 +365,12 @@ class TextBoxDrawer(object):
         # Dummy image draw because multiline_textsize isn't a @classmethod
         dummy_img = Image.new("1", (1, 1))
         dummy_draw = ImageDraw.Draw(dummy_img)
-        text_width, text_height = dummy_draw.multiline_textsize(
+        left, top, right, bottom = dummy_draw.multiline_textbbox(
+            (0, 0),
             "\n".join(lines),
             font=font,
             spacing=line_spacing)
-
-        # Reduce text_height by offset at top
+        text_width, text_height = right - left, bottom - top
         text_height -= cls.get_font_y_offset(font)
         return lines, text_width, text_height
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,21 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
+7.4.0
+==============================================================================
+
+**Release date:** 19 April 2024
+
+**Changelog:**
+
+- Fix helper commands documentation
+- Fix style checks failing
+- Update gulpfile from cjs to ejs file
+- Disable scroll view on small screens in slides
+- Django 4.2 compatibility changes
+- Dependency updates:
+    - Todo
+
 7.3.0
 ==============================================================================
 
@@ -50,10 +65,6 @@ All notable changes to this project will be documented in this file.
     - Update sphinx-rtd-theme from 1.1.0 to 1.1.1.
     - Update django-debug-toolbar from 3.7.0 to 3.8.1.
     - Update actions/setup-python from 4.3.0 to 4.3.1.
-
-
-
-
 
 7.2.1
 ==============================================================================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,8 +35,58 @@ All notable changes to this project will be documented in this file.
 - Update gulpfile from cjs to ejs file
 - Disable scroll view on small screens in slides
 - Django 4.2 compatibility changes
-- Dependency updates:
-    - Todo
+- Update Node image to latest LTS.
+- Python dependency changes:
+    - Update sphinx from 4.4.0 to 7.3.6
+    - Update sphinx-rtd-theme from 1.1.1 to 2.0.0
+    - Update django from 3.2.16 to 4.2.11
+    - Update django-environ from 0.9.0 to 0.11.2
+    - Update gunicorn from 20.1.0 to 22.0.0
+    - Update whitenoise from 6.2.0 to 6.6.0
+    - Update psycopg2 from 2.9.5 to 2.9.9
+    - Update Pillow from 9.3.0 to 9.5.0
+    - Update yattag from 1.14.0 to 1.15.2
+    - Update verto from 1.0.1 to 1.1.1
+    - Update PyYAML from 6.0 to 6.0.1
+    - Update tqdm from 4.64.1 to 4.66.2
+    - Update lxml from 4.9.2 to 5.2.1
+    - Update django-modeltranslation from 0.18.7 to 0.18.11
+    - Update uniseg from 0.7.2 to 0.8.0
+    - Update requests 2.28.1 to 2.31.0
+    - Update django-cors-headers from 3.13.0 to 4.3.1
+    - Update django-debug-toolbar from 3.8.1 to 4.3.0
+    - Update django-extensions from 3.2.1 to 3.2.3
+    - Update flake8 from 4.0.1 to 7.0.0
+    - Update pydocstyle from 6.1.1 to 6.3.0
+    - Update coverage from 6.5.0 to 7.4.4
+    - Remove PyPDF2
+    - Add pypdf 3.17.4
+- JS dependency changes:
+    - Update autoprefixer from 10.4.13 to 10.4.19
+    - Update browser-sync from 3.0.2
+    - Update cssnano from 5.1.14 to 6.1.2
+    - Update blockly from 7.20211209.2 to 10.4.3
+    - Update gulp-filter from 7.0.0 to 9.0.1
+    - Update gulp-imagemin from 7.1.0 to 9.0.0
+    - Update gulp-postcss from 9.0.1 to 10.0.0
+    - Update intro.js from 4.3.0 to 7.2.0
+    - Update jquery from 3.6.2 to 3.7.1
+    - Update multiple-select from 1.5.2 to 1.7.0
+    - Update postcss from 8.4.20 to 8.4.38
+    - Update reveal.js from 4.4.0 to 5.1.0
+    - Update sass from 1.56.2 to 1.75.0
+    - Update scratchblocks from 3.6.1 to 3.6.4
+    - Update yargs from 17.6.2 to 17.7.2
+- Github Action dependency changes:
+    - Update actions/checkout from 3 to 4
+    - Update actions/setup-python from 4.3.1 to 5.1.0
+    - Update actions/upload-artifact from 3 to 4
+    - Update actions/download-artifact from 3 to 4
+    - Update crowdin/github-action from 1.5.2 to 1.20.2
+    - Update dependabot/fetch-metadata from 1.3.5 to 2.0.0
+    - Update docker/metadata-action from 4 to 5
+    - Update docker/login-action from 2.1.0 to v3.1.0
+    - Update docker/build-push-action from 3.2.0 to 5.3.0
 
 7.3.0
 ==============================================================================

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,33 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
-7.2.1
+7.5.0
+==============================================================================
+
+**Release date:** 22 May 2024
+
+**Changelog:**
+
+- Fix jobe access issue breaking Plugging it in test code button in staging.
+- Update worksheets for compatibility with Pilow 10
+- Update docker images to use debian bookworm
+- Update docker images to python 3.11
+- Core Dependency changes:
+
+    - Update crowdin/github-action from 1.20.2 to 1.20.4
+    - Update codecov/codecov-action from 3 to 4
+    - Update cssnano from 6.1.2 to 7.0.1
+    - Update gulp-imagemin from 9.0.0 to 9.1.0
+    - Update sass from 1.75.0 to 1.77.2
+    - Update Pillow from 9.5.0 to 10.3.0
+    - Update tqdm from 4.66.2 to 4.66.4
+    - Update lxml from 5.2.1 to 5.2.2
+    - Update django-modeltranslation from 0.18.11 to 0.18.13
+    - Update requests from 2.31.0 to 2.32.2
+    - Update coverage from 7.4.4 to 7.5.1
+    - Update pypdf from 3.17.4 to 4.2.0
+
+7.4.1
 ==============================================================================
 
 **Release date:** 19 April 2024

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,15 @@ All notable changes to this project will be documented in this file.
   fit the Semantic Versioning model. However these version numbers can still
   provide a good indication of the changes in each version.
 
+7.2.1
+==============================================================================
+
+**Release date:** 19 April 2024
+
+**Changelog:**
+
+- Fix jobe access issue breaking Plugging it in test code button.
+
 7.4.0
 ==============================================================================
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.2.6
+sphinx==7.3.4
 sphinx-rtd-theme==2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.3.4
+sphinx==7.3.6
 sphinx-rtd-theme==2.0.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==7.3.6
+sphinx==7.3.7
 sphinx-rtd-theme==2.0.0

--- a/infrastructure/local/django/Dockerfile
+++ b/infrastructure/local/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-slim-buster as python
+FROM python:3.11.9-slim-bookworm as python
 
 # Python build stage ----------------------------------------------------------
 FROM python as python-build-stage

--- a/infrastructure/local/docs/Dockerfile
+++ b/infrastructure/local/docs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9-slim-buster
+FROM python:3.12-slim-bookworm
 
 ENV PYTHONUNBUFFERED 1
 ENV PYTHONDONTWRITEBYTECODE 1

--- a/infrastructure/local/node/Dockerfile
+++ b/infrastructure/local/node/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-buster
+FROM node:20-bookworm
 
 ARG DOCKER_UID=1000
 RUN usermod -u $DOCKER_UID node
@@ -14,7 +14,6 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
     libgif-dev \
     librsvg2-dev \
     make \
-    python \
     # Cleaning up unused files
     && apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false \
     && rm -rf /var/lib/apt/lists/*

--- a/infrastructure/production/django/Dockerfile
+++ b/infrastructure/production/django/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.5-slim-buster as python
+FROM python:3.11.9-slim-bookworm as python
 
 # Python build stage ----------------------------------------------------------
 FROM python as python-build-stage

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ PyYAML==6.0.1
 tqdm==4.66.4
 
 # XML Parsing
-lxml==5.2.1
+lxml==5.2.2
 cssselect==1.2.0
 
 # I18n

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ python-bidi==0.4.2
 django-bidi-utils==1.0
 
 # Plugging it in
-requests==2.32.1
+requests==2.32.2
 
 # CORS
 django-cors-headers==4.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -37,7 +37,7 @@ python-bidi==0.4.2
 django-bidi-utils==1.0
 
 # Plugging it in
-requests==2.31.0
+requests==2.32.1
 
 # CORS
 django-cors-headers==4.3.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ psycopg2==2.9.9
 
 # Resources
 WeasyPrint==52.4
-Pillow==9.5.0
+Pillow==10.1.0
 yattag==1.15.2
 tinycss==0.4
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ python-markdown-math==0.6
 PyYAML==6.0.1
 
 # System tools
-tqdm==4.66.2
+tqdm==4.66.4
 
 # XML Parsing
 lxml==5.2.1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,7 @@ django-environ==0.11.2
 django-bootstrap-breadcrumbs==0.9.2
 
 # Web serving
-gunicorn==21.2.0
+gunicorn==22.0.0
 whitenoise==6.6.0
 
 # Database APIs

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,7 +12,7 @@ psycopg2==2.9.9
 
 # Resources
 WeasyPrint==52.4
-Pillow==10.1.0
+Pillow==10.3.0
 yattag==1.15.2
 tinycss==0.4
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Django
-django==4.2.10
+django==4.2.11
 django-environ==0.11.2
 django-bootstrap-breadcrumbs==0.9.2
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ PyYAML==6.0.1
 tqdm==4.66.2
 
 # XML Parsing
-lxml==5.1.0
+lxml==5.2.0
 cssselect==1.2.0
 
 # I18n

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -27,7 +27,7 @@ PyYAML==6.0.1
 tqdm==4.66.2
 
 # XML Parsing
-lxml==5.2.0
+lxml==5.2.1
 cssselect==1.2.0
 
 # I18n

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -31,7 +31,7 @@ lxml==5.2.2
 cssselect==1.2.0
 
 # I18n
-django-modeltranslation==0.18.11
+django-modeltranslation==0.18.13
 uniseg==0.8.0
 python-bidi==0.4.2
 django-bidi-utils==1.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ flake8==7.0.0
 pydocstyle==6.3.0
 
 # Coverage Tools
-coverage==7.4.4
+coverage==7.5.0
 
 # Skip migration files for local testing
 django-test-without-migrations==0.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ flake8==7.0.0
 pydocstyle==6.3.0
 
 # Coverage Tools
-coverage==7.4.2
+coverage==7.4.3
 
 # Skip migration files for local testing
 django-test-without-migrations==0.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ flake8==7.0.0
 pydocstyle==6.3.0
 
 # Coverage Tools
-coverage==7.4.3
+coverage==7.4.4
 
 # Skip migration files for local testing
 django-test-without-migrations==0.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,7 +5,7 @@ flake8==7.0.0
 pydocstyle==6.3.0
 
 # Coverage Tools
-coverage==7.5.0
+coverage==7.5.1
 
 # Skip migration files for local testing
 django-test-without-migrations==0.6

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -11,4 +11,4 @@ coverage==7.5.1
 django-test-without-migrations==0.6
 
 # PDF file checking
-pypdf==3.17.4
+pypdf==4.2.0


### PR DESCRIPTION
- Fix jobe access issue breaking Plugging it in test code button in staging.
- Update worksheets for compatibility with Pilow 10
- Update docker images to use debian bookworm
- Update docker images to python 3.11
- Core Dependency changes:

    - Update crowdin/github-action from 1.20.2 to 1.20.4
    - Update codecov/codecov-action from 3 to 4
    - Update cssnano from 6.1.2 to 7.0.1
    - Update gulp-imagemin from 9.0.0 to 9.1.0
    - Update sass from 1.75.0 to 1.77.2
    - Update Pillow from 9.5.0 to 10.3.0
    - Update tqdm from 4.66.2 to 4.66.4
    - Update lxml from 5.2.1 to 5.2.2
    - Update django-modeltranslation from 0.18.11 to 0.18.13
    - Update requests from 2.31.0 to 2.32.2
    - Update coverage from 7.4.4 to 7.5.1
    - Update pypdf from 3.17.4 to 4.2.0