### PR TITLE
Clarify Python hint needs int() conversion for card input (#2595)

### DIFF
--- a/csunplugged/topics/content/en/binary-numbers/programming-challenges/number-cards-display/python-hints.md
+++ b/csunplugged/topics/content/en/binary-numbers/programming-challenges/number-cards-display/python-hints.md
@@ -6,5 +6,6 @@
 -   In this challenge, use the `input()` function to receive input from the
     user. Place text inside the brackets of input with your question. The user input
     will be stored whichever variable you assign it to. Set the value of variable
-    `number_of_cards` to the input you received. Use a for loop, repeating the
-    blocks inside (displaying the number of dots) `number_of_cards` times.
+    `number_of_cards` to the input you received, then use `int()` to convert the
+    input from a string into a number. Use a for loop, repeating the blocks
+    inside (displaying the number of dots) `number_of_cards` times.


### PR DESCRIPTION
## Proposed changes

The hint for the "Display number of dots for a given number of cards" Python
challenge tells students to assign the result of `input()` straight to
`number_of_cards`, but the published solution and all three test cases require an
integer. Without converting it, `range(number_of_cards)` raises `TypeError`, so
the hint contradicts the worked solution and can confuse learners. This adds the
missing conversion step.

### Root cause

`csunplugged/topics/content/en/binary-numbers/programming-challenges/number-cards-display/python-hints.md`
omits the string-to-int conversion that the sibling `python-solution.md`
performs via `number_of_cards = int(input(...))`. The testing examples (inputs
`5`, `8`, `1`) all rely on integer input.

### Solution

Add "then use `int()` to convert the input from a string into a number" to the
existing hint bullet, matching the house style of backticked function names
(`input()`, `print()`). English source only; translations are propagated via
Crowdin.

### Testing

English-source content change only. There is no automated test harness for hint
text (cf. merged #2692), and no new Verto/glossary constructs are introduced, so
content loading via `updatedata` is unaffected. Verified statically that the
hint now matches `python-solution.md` and the testing examples.

Reported by @timcharlier6.

Closes #2595

### Checklist

- [x] I have read the contribution guidelines.
- [x] I have linked the relevant issue (#2595) in the description above.
- [x] The pull request is requesting a merge into the `develop` branch.
- [x] I have added necessary documentation (if appropriate).
- [x] If I've added/modified/deleted a third-party system, I've updated the relevant license files.
